### PR TITLE
Baseline Prisma migration for existing database

### DIFF
--- a/prisma/migrations/0001_init/migration.sql
+++ b/prisma/migrations/0001_init/migration.sql
@@ -1,7 +1,0 @@
-CREATE TABLE "User" (
-  "id" SERIAL PRIMARY KEY,
-  "name" TEXT,
-  "email" TEXT NOT NULL UNIQUE,
-  "password" TEXT NOT NULL,
-  "image" TEXT
-);

--- a/prisma/migrations/0_init/migration.sql
+++ b/prisma/migrations/0_init/migration.sql
@@ -1,0 +1,17 @@
+-- CreateSchema
+CREATE SCHEMA IF NOT EXISTS "public";
+
+-- CreateTable
+CREATE TABLE "public"."User" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT,
+    "email" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "image" TEXT,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "public"."User"("email");
+


### PR DESCRIPTION
## Summary
- replace prior migration with `0_init` baseline
- generate baseline SQL from current Prisma schema

## Testing
- `npm test` *(fails: Missing script "test")*
- `DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres" npx prisma migrate resolve --applied 0_init` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_6894fe982f8483208db98a24b46ced2a