### PR TITLE
Run database baseline during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "npm run baseline && next build",
     "start": "next start",
     "lint": "next lint",
     "migrate": "prisma migrate deploy",
     "seed": "prisma db seed",
-    "vercel-build": "npm run migrate && npm run seed && next build"
+    "baseline": "node prisma/baseline.js",
+    "vercel-build": "npm run baseline && next build"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.8.2",

--- a/prisma/baseline.js
+++ b/prisma/baseline.js
@@ -1,0 +1,7 @@
+const { execSync } = require('child_process');
+
+function resetDatabase() {
+  execSync('npx prisma migrate reset --force', { stdio: 'inherit' });
+}
+
+resetDatabase();


### PR DESCRIPTION
## Summary
- reset database using Prisma migrate before building
- wire up baseline script for standard and Vercel builds

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_689502a8e36c83209feb1f8ee14173c8