### PR TITLE
Implement credential-based auth with registration route

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { register } from "../../../lib/controllers/authController";
+
+export async function POST(req: Request) {
+  try {
+    const data = await req.json();
+    const user = await register({
+      name: data.name,
+      email: data.email,
+      password: data.password,
+    });
+    return NextResponse.json({ user });
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message || "Registration failed" }, { status: 400 });
+  }
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { Box, Input, Stack, Heading, Button, Textarea, Progress } from "@chakra-ui/react";
-import NextLink from "next/link";
+import { useRouter } from "next/navigation";
 
 export default function SignUpPage() {
   const [form, setForm] = useState({
@@ -20,13 +20,23 @@ export default function SignUpPage() {
     setForm((prev) => ({ ...prev, [name]: value }));
   };
 
-  const canProceed = form.name && form.email && form.password;
+  const router = useRouter();
+  const canSubmit = form.name && form.email && form.password;
+
+  const handleSubmit = async () => {
+    const res = await fetch("/api/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: form.name, email: form.email, password: form.password }),
+    });
+    if (res.ok) router.push("/login");
+  };
 
   return (
     <Box maxW="lg" mx="auto" mt={10} p={6} bg="white" shadow="md" borderRadius="lg">
-      <Progress value={33} mb={6} />
+      <Progress value={100} mb={6} />
       <Heading size="md" mb={6} textAlign="center">
-        Step 1 of 3
+        Sign Up
       </Heading>
       <Stack spacing={4}>
         <Input placeholder="Full Name" name="name" value={form.name} onChange={handleChange} />
@@ -36,8 +46,8 @@ export default function SignUpPage() {
         <Input placeholder="Location" name="location" value={form.location} onChange={handleChange} />
         <Textarea placeholder="Professional Bio" name="bio" value={form.bio} onChange={handleChange} />
         <Input placeholder="Areas of Expertise (optional)" name="expertise" value={form.expertise} onChange={handleChange} />
-        <Button as={NextLink} href="/signup/financial" colorScheme="brand" isDisabled={!canProceed}>
-          Next
+        <Button onClick={handleSubmit} colorScheme="brand" isDisabled={!canSubmit}>
+          Register
         </Button>
       </Stack>
     </Box>

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,8 +1,8 @@
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import { PrismaClient } from "@prisma/client";
 import Credentials from "next-auth/providers/credentials";
-import bcrypt from "bcryptjs";
 import type { NextAuthOptions } from "next-auth";
+import { validateUser } from "./services/authService";
 
 const prisma = new PrismaClient();
 
@@ -16,11 +16,7 @@ export const authOptions: NextAuthOptions = {
       },
       async authorize(credentials) {
         if (!credentials?.email || !credentials.password) return null;
-        const user = await prisma.user.findUnique({ where: { email: credentials.email } });
-        if (!user) return null;
-        const valid = await bcrypt.compare(credentials.password, user.password);
-        if (!valid) return null;
-        return { id: String(user.id), email: user.email, name: user.name };
+        return validateUser(credentials.email, credentials.password);
       },
     }),
   ],

--- a/lib/controllers/authController.ts
+++ b/lib/controllers/authController.ts
@@ -1,0 +1,6 @@
+import { registerUser } from "../services/authService";
+
+export async function register(data: { name?: string; email: string; password: string }) {
+  const user = await registerUser(data);
+  return { id: user.id, email: user.email, name: user.name };
+}

--- a/lib/services/authService.ts
+++ b/lib/services/authService.ts
@@ -1,0 +1,25 @@
+import { PrismaClient } from "@prisma/client";
+import bcrypt from "bcryptjs";
+
+const prisma = new PrismaClient();
+
+export async function getUserByEmail(email: string) {
+  return prisma.user.findUnique({ where: { email } });
+}
+
+export async function registerUser(data: { name?: string; email: string; password: string }) {
+  const existing = await getUserByEmail(data.email);
+  if (existing) throw new Error("Email already in use");
+  const hashedPassword = await bcrypt.hash(data.password, 10);
+  return prisma.user.create({
+    data: { name: data.name, email: data.email, password: hashedPassword },
+  });
+}
+
+export async function validateUser(email: string, password: string) {
+  const user = await getUserByEmail(email);
+  if (!user) return null;
+  const valid = await bcrypt.compare(password, user.password);
+  if (!valid) return null;
+  return { id: String(user.id), email: user.email, name: user.name };
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,5 @@
+export { default } from "next-auth/middleware";
+
+export const config = {
+  matcher: ["/dashboard/:path*", "/profile"],
+};


### PR DESCRIPTION
## Summary
- add controller/service layer for auth logic
- create `/api/register` endpoint for user signup
- enforce session checks on dashboard and profile via NextAuth middleware
- wire signup page to registration endpoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_689506460af883209f0f7097ac641fb4