### PR TITLE
feat: add landing page testimonials and prisma util

### DIFF
--- a/app/api/testimonials/route.ts
+++ b/app/api/testimonials/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+export async function GET() {
+  const testimonials = await prisma.testimonial.findMany({
+    orderBy: { id: "asc" },
+  });
+  return NextResponse.json(testimonials);
+}

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,0 +1,8 @@
+.header {
+  transition: background-color 0.3s ease;
+}
+
+.scrolled {
+  background-color: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,33 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Box, Button, Flex, Heading, Text, Stack, SimpleGrid, Icon, Image, Link } from "@chakra-ui/react";
 import NextLink from "next/link";
 import { FaBrain, FaTasks, FaChartLine } from "react-icons/fa";
+import TestimonialCarousel from "@/components/TestimonialCarousel";
+import styles from "./page.module.css";
 
 export default function LandingPage() {
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  useEffect(() => {
+    const handler = () => setIsScrolled(window.scrollY > 10);
+    handler();
+    window.addEventListener("scroll", handler);
+    return () => window.removeEventListener("scroll", handler);
+  }, []);
+
   return (
     <Box>
-      <Flex as="header" justify="space-between" align="center" p={4} position="sticky" top={0} bg="white" boxShadow="sm">
+      <Flex
+        as="header"
+        justify="space-between"
+        align="center"
+        p={4}
+        position="sticky"
+        top={0}
+        className={`${styles.header} ${isScrolled ? styles.scrolled : ""}`}
+      >
         <Heading size="md">Orbas</Heading>
         <Stack direction="row" spacing={4} align="center">
           <Button as={NextLink} href="/login" variant="ghost">Login</Button>
@@ -42,8 +62,9 @@ export default function LandingPage() {
       </Box>
 
       <Box py={20} px={4} bg="gray.50" textAlign="center">
-        <Heading size="lg" mb={6}>Trusted by innovators</Heading>
-        <Stack direction="row" spacing={10} justify="center" align="center">
+        <Heading size="lg" mb={6}>What people are saying</Heading>
+        <TestimonialCarousel />
+        <Stack direction="row" spacing={10} justify="center" align="center" mt={10}>
           <Image src="/next.svg" alt="Partner" boxSize="60px" opacity={0.6} />
           <Image src="/vercel.svg" alt="Partner" boxSize="60px" opacity={0.6} />
         </Stack>

--- a/components/TestimonialCarousel.module.css
+++ b/components/TestimonialCarousel.module.css
@@ -1,0 +1,3 @@
+.carousel {
+  transition: opacity 0.5s ease-in-out;
+}

--- a/components/TestimonialCarousel.tsx
+++ b/components/TestimonialCarousel.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Avatar, Box, Flex, Spinner, Text } from "@chakra-ui/react";
+import { fetchJson } from "@/lib/fetcher";
+import styles from "./TestimonialCarousel.module.css";
+
+interface Testimonial {
+  id: number;
+  name: string;
+  message: string;
+  avatarUrl?: string | null;
+}
+
+export default function TestimonialCarousel() {
+  const [testimonials, setTestimonials] = useState<Testimonial[]>([]);
+  const [index, setIndex] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await fetchJson<Testimonial[]>("/api/testimonials");
+        setTestimonials(data);
+      } catch (err) {
+        console.error("Failed to load testimonials", err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  useEffect(() => {
+    if (!testimonials.length) return;
+    const interval = setInterval(() => {
+      setIndex((prev) => (prev + 1) % testimonials.length);
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [testimonials]);
+
+  if (loading) {
+    return (
+      <Flex justify="center" align="center" py={10}>
+        <Spinner />
+      </Flex>
+    );
+  }
+
+  if (!testimonials.length) return null;
+
+  const t = testimonials[index];
+
+  return (
+    <Box className={styles.carousel}>
+      <Flex direction="column" align="center" maxW="xl" mx="auto" textAlign="center" px={4}>
+        {t.avatarUrl && <Avatar src={t.avatarUrl || undefined} name={t.name} size="lg" mb={4} />}
+        <Text fontStyle="italic" mb={2}>&quot;{t.message}&quot;</Text>
+        <Text fontWeight="bold">- {t.name}</Text>
+      </Flex>
+    </Box>
+  );
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,10 +1,8 @@
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
-import { PrismaClient } from "@prisma/client";
+import prisma from "@/lib/prisma";
 import Credentials from "next-auth/providers/credentials";
 import type { NextAuthOptions } from "next-auth";
 import { validateUser } from "./services/authService";
-
-const prisma = new PrismaClient();
 
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),

--- a/lib/fetcher.ts
+++ b/lib/fetcher.ts
@@ -1,0 +1,7 @@
+export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    throw new Error(`Request failed with status ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined };
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({
+    log: process.env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"]
+  });
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+
+export default prisma;

--- a/lib/services/authService.ts
+++ b/lib/services/authService.ts
@@ -1,7 +1,5 @@
-import { PrismaClient } from "@prisma/client";
+import prisma from "@/lib/prisma";
 import bcrypt from "bcryptjs";
-
-const prisma = new PrismaClient();
 
 export async function getUserByEmail(email: string) {
   return prisma.user.findUnique({ where: { email } });

--- a/prisma/migrations/20250207000000_add_testimonials/migration.sql
+++ b/prisma/migrations/20250207000000_add_testimonials/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "public"."Testimonial" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "avatarUrl" TEXT,
+    CONSTRAINT "Testimonial_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,3 +14,10 @@ model User {
   password String
   image    String?
 }
+
+model Testimonial {
+  id        Int    @id @default(autoincrement())
+  name      String
+  message   String
+  avatarUrl String?
+}

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -14,6 +14,22 @@ async function main() {
       password,
     },
   });
+
+  await prisma.testimonial.createMany({
+    data: [
+      {
+        name: 'Jane Doe',
+        message: 'Orbas helped us hire top talent quickly and efficiently.',
+        avatarUrl: null,
+      },
+      {
+        name: 'John Smith',
+        message: 'The gig management tools saved our team countless hours.',
+        avatarUrl: null,
+      },
+    ],
+    skipDuplicates: true,
+  });
 }
 
 main()


### PR DESCRIPTION
## Summary
- add Prisma utility and fetch helper
- create testimonial model, seed data, and API endpoint
- enhance landing page with scroll-aware header and testimonial carousel

## Testing
- `npm test` (fails: Missing script: test)
- `npm run lint`
- `npm run migrate` (fails: Environment variable not found: DATABASE_URL)

------
https://chatgpt.com/codex/tasks/task_e_68950d22d0e08320bcf6091658c00e37