### PR TITLE
Skip env push during Vercel builds

### DIFF
--- a/scripts/push-vercel-env.js
+++ b/scripts/push-vercel-env.js
@@ -2,9 +2,20 @@
 const fs = require('fs');
 const { spawnSync } = require('child_process');
 
+// Vercel manages environment variables through its dashboard. When building
+// on Vercel, the `.env` file is not present and we should not attempt to push
+// local values. Detect the Vercel environment and exit gracefully.
+if (process.env.VERCEL) {
+  console.log('Vercel build detected, skipping env push.');
+  process.exit(0);
+}
+
+// When developing locally, the `.env` file might not exist if variables are
+// already configured. Instead of failing, simply skip pushing the values so the
+// build can continue.
 if (!fs.existsSync('.env')) {
-  console.error('.env file not found');
-  process.exit(1);
+  console.log('.env file not found, skipping env push.');
+  process.exit(0);
 }
 
 const env = fs.readFileSync('.env', 'utf8');


### PR DESCRIPTION
## Summary
- avoid failing builds when `.env` is missing on Vercel by exiting early
- skip pushing env vars to Vercel in CI since Vercel manages them

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689514aba0708320825377b81cfe3624