### PR TITLE
chore: skip prisma reset in non-dev env

### DIFF
--- a/prisma/baseline.js
+++ b/prisma/baseline.js
@@ -1,7 +1,23 @@
 const { execSync } = require('child_process');
 
 function resetDatabase() {
-  execSync('npx prisma migrate reset --force', { stdio: 'inherit' });
+  // Avoid running reset in environments where a database connection
+  // isn't expected (e.g. production, CI or missing env vars)
+  if (
+    process.env.CI ||
+    process.env.VERCEL ||
+    process.env.NODE_ENV === 'production' ||
+    !process.env.DATABASE_URL
+  ) {
+    console.log('Skipping prisma migrate reset');
+    return;
+  }
+
+  try {
+    execSync('npx prisma migrate reset --force', { stdio: 'inherit' });
+  } catch (error) {
+    console.error('Failed to reset database', error);
+  }
 }
 
 resetDatabase();


### PR DESCRIPTION
## Summary
- skip prisma migrate reset when running in production, CI, Vercel, or when DATABASE_URL is not set
- catch and log errors instead of exiting

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689520691cf08320b1bdb948e9c1da69