### PR TITLE
Ensure Prisma client generated during build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/react-google-recaptcha": "^2.1.9",
         "eslint": "^9.32.0",
         "eslint-config-next": "^15.4.5",
         "prisma": "^6.13.0",
@@ -1957,6 +1958,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/react-google-recaptcha": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react-google-recaptcha/-/react-google-recaptcha-2.1.9.tgz",
+      "integrity": "sha512-nT31LrBDuoSZJN4QuwtQSF3O89FVHC4jLhM+NtKEmVF5R1e8OY0Jo4//x2Yapn2aNHguwgX5doAq8Zo+Ehd0ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/react-google-recaptcha": "^2.1.9",
     "eslint": "^9.32.0",
     "eslint-config-next": "^15.4.5",
     "prisma": "^6.13.0",

--- a/prisma/baseline.js
+++ b/prisma/baseline.js
@@ -20,4 +20,13 @@ function resetDatabase() {
   }
 }
 
+function generateClient() {
+  try {
+    execSync('npx prisma generate', { stdio: 'inherit' });
+  } catch (error) {
+    console.error('Failed to generate Prisma client', error);
+  }
+}
+
 resetDatabase();
+generateClient();


### PR DESCRIPTION
## Summary
- Always run `prisma generate` during baseline to keep Prisma client in sync
- Add `@types/react-google-recaptcha` to satisfy missing type declarations

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689522266aa483208398e6fb685d5cda