### PR TITLE
Gracefully handle missing reCAPTCHA configuration

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -31,6 +31,8 @@ export default function LoginPage() {
   const [rememberMe, setRememberMe] = useState(false);
   const [error, setError] = useState("");
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
+  const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
+  const recaptchaEnabled = Boolean(siteKey);
 
   useEffect(() => {
     if (session) router.replace("/dashboard");
@@ -95,10 +97,12 @@ export default function LoginPage() {
               type="password"
             />
           </FormControl>
-          <ReCAPTCHA
-            sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY!}
-            onChange={(token) => setCaptchaToken(token)}
-          />
+          {recaptchaEnabled && (
+            <ReCAPTCHA
+              sitekey={siteKey as string}
+              onChange={(token) => setCaptchaToken(token)}
+            />
+          )}
           <Stack direction="row" justify="space-between" align="center">
             <Checkbox isChecked={rememberMe} onChange={(e) => setRememberMe(e.target.checked)}>
               Remember Me
@@ -107,7 +111,11 @@ export default function LoginPage() {
               Forgot Password?
             </Link>
           </Stack>
-          <Button type="submit" colorScheme="brand" isDisabled={!captchaToken}>
+          <Button
+            type="submit"
+            colorScheme="brand"
+            isDisabled={recaptchaEnabled && !captchaToken}
+          >
             Sign In
           </Button>
         </Stack>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -20,6 +20,8 @@ export default function SignUpPage() {
     expertise: data.expertise || "",
   });
   const [captcha, setCaptcha] = useState<string | null>(null);
+  const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
+  const recaptchaEnabled = Boolean(siteKey);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
@@ -27,7 +29,11 @@ export default function SignUpPage() {
   };
 
   const router = useRouter();
-  const canSubmit = form.name && form.email && form.password && captcha;
+  const canSubmit =
+    form.name &&
+    form.email &&
+    form.password &&
+    (!recaptchaEnabled || captcha);
 
   const handleNext = () => {
     setData(form);
@@ -55,8 +61,15 @@ export default function SignUpPage() {
         <Input placeholder="Password" name="password" type="password" value={form.password} onChange={handleChange} />
         <Input placeholder="Location" name="location" value={form.location} onChange={handleChange} />
         <Textarea placeholder="Professional Bio" name="bio" value={form.bio} onChange={handleChange} />
-        <Input placeholder="Areas of Expertise (optional)" name="expertise" value={form.expertise} onChange={handleChange} />
-        <ReCAPTCHA sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || ""} onChange={setCaptcha} />
+        <Input
+          placeholder="Areas of Expertise (optional)"
+          name="expertise"
+          value={form.expertise}
+          onChange={handleChange}
+        />
+        {recaptchaEnabled && (
+          <ReCAPTCHA sitekey={siteKey as string} onChange={setCaptcha} />
+        )}
         <Button onClick={handleNext} colorScheme="brand" isDisabled={!canSubmit}>
           Next
         </Button>


### PR DESCRIPTION
## Summary
- Skip rendering and requirement of reCAPTCHA when no site key is configured for login/signup
- Prevent submission buttons from staying disabled when reCAPTCHA is unavailable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68952798ae508320aab93abfa232a8ca