### PR TITLE
Enhance auth flow and landing page

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -20,8 +20,12 @@ export async function POST(req: Request) {
       resume: data.resume,
       coverLetter: data.coverLetter,
     });
-    return NextResponse.json({ user });
+    return NextResponse.json({ user }, { status: 201 });
   } catch (e: any) {
-    return NextResponse.json({ error: e.message || "Registration failed" }, { status: 400 });
+    console.error("Registration error", e);
+    return NextResponse.json(
+      { error: e.message || "Registration failed" },
+      { status: 400 }
+    );
   }
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -31,6 +31,7 @@ export default function LoginPage() {
   const [rememberMe, setRememberMe] = useState(false);
   const [error, setError] = useState("");
   const [captchaToken, setCaptchaToken] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
   const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
   const recaptchaEnabled = Boolean(siteKey);
 
@@ -49,6 +50,7 @@ export default function LoginPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
+    setSubmitting(true);
     const res = await signIn("credentials", {
       email,
       password,
@@ -56,6 +58,7 @@ export default function LoginPage() {
     });
     if (res?.error) {
       setError("Invalid email or password");
+      setSubmitting(false);
       return;
     }
     if (rememberMe) {
@@ -64,6 +67,7 @@ export default function LoginPage() {
       localStorage.removeItem("rememberedEmail");
     }
     router.push("/dashboard");
+    setSubmitting(false);
   };
 
   return (
@@ -114,7 +118,8 @@ export default function LoginPage() {
           <Button
             type="submit"
             colorScheme="brand"
-            isDisabled={recaptchaEnabled && !captchaToken}
+            isDisabled={(recaptchaEnabled && !captchaToken) || submitting}
+            isLoading={submitting}
           >
             Sign In
           </Button>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,19 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Box, Button, Flex, Heading, Text, Stack, SimpleGrid, Icon, Image, Link } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  Text,
+  Stack,
+  SimpleGrid,
+  Icon,
+  Image,
+  Link,
+  Container,
+} from "@chakra-ui/react";
 import NextLink from "next/link";
 import { FaBrain, FaTasks, FaChartLine } from "react-icons/fa";
 import TestimonialCarousel from "@/components/TestimonialCarousel";
@@ -27,61 +39,116 @@ export default function LandingPage() {
         position="sticky"
         top={0}
         className={`${styles.header} ${isScrolled ? styles.scrolled : ""}`}
+        bg="white"
+        zIndex={10}
       >
         <Heading size="md">Orbas</Heading>
-        <Stack direction="row" spacing={4} align="center">
-          <Button as={NextLink} href="/login" variant="ghost">Login</Button>
-          <Button as={NextLink} href="/signup" colorScheme="brand">Sign Up</Button>
+        <Stack direction="row" spacing={6} align="center">
+          <Link as={NextLink} href="#features">Features</Link>
+          <Link as={NextLink} href="#about">About</Link>
+          <Button as={NextLink} href="/login" variant="ghost">
+            Login
+          </Button>
+          <Button as={NextLink} href="/signup" colorScheme="brand">
+            Sign Up
+          </Button>
         </Stack>
       </Flex>
 
       <Box textAlign="center" py={24} px={4} bg="gray.50">
-        <Heading size="2xl" mb={4}>Revolutionize Your Recruitment & Gig Management</Heading>
-        <Text fontSize="lg" mb={8}>AI-powered matching, integrated gig management and real-time analytics.</Text>
-        <Button colorScheme="brand" size="lg" as={NextLink} href="/signup">Get Started</Button>
+        <Container maxW="4xl">
+          <Heading size="2xl" mb={4}>
+            Empowering Talent with AI and Insight
+          </Heading>
+          <Text fontSize="lg" mb={8}>
+            Streamline recruiting, manage gigs, and track performance with one integrated platform.
+          </Text>
+          <Button colorScheme="brand" size="lg" as={NextLink} href="/signup">
+            Get Started
+          </Button>
+        </Container>
       </Box>
 
-      <Box py={20} px={4}>
-        <SimpleGrid columns={{ base: 1, md: 3 }} spacing={8}>
-          <Stack align="center" spacing={3}>
-            <Icon as={FaBrain} boxSize={8} color="brand.500" />
-            <Heading size="md">AI-Powered Matching</Heading>
-            <Text textAlign="center">Connect with the right opportunities using intelligent algorithms.</Text>
-          </Stack>
-          <Stack align="center" spacing={3}>
-            <Icon as={FaTasks} boxSize={8} color="brand.500" />
-            <Heading size="md">Integrated Gig Management</Heading>
-            <Text textAlign="center">Manage tasks and projects seamlessly in one place.</Text>
-          </Stack>
-          <Stack align="center" spacing={3}>
-            <Icon as={FaChartLine} boxSize={8} color="brand.500" />
-            <Heading size="md">Real-Time Analytics</Heading>
-            <Text textAlign="center">Gain insights with up-to-the-minute data and reports.</Text>
-          </Stack>
-        </SimpleGrid>
+      <Box py={20} px={4} id="features">
+        <Container maxW="6xl">
+          <SimpleGrid columns={{ base: 1, md: 3 }} spacing={8}>
+            <Stack align="center" spacing={3}>
+              <Icon as={FaBrain} boxSize={8} color="brand.500" />
+              <Heading size="md">AI-Powered Matching</Heading>
+              <Text textAlign="center">Connect with the right opportunities using intelligent algorithms.</Text>
+            </Stack>
+            <Stack align="center" spacing={3}>
+              <Icon as={FaTasks} boxSize={8} color="brand.500" />
+              <Heading size="md">Integrated Gig Management</Heading>
+              <Text textAlign="center">Manage tasks and projects seamlessly in one place.</Text>
+            </Stack>
+            <Stack align="center" spacing={3}>
+              <Icon as={FaChartLine} boxSize={8} color="brand.500" />
+              <Heading size="md">Real-Time Analytics</Heading>
+              <Text textAlign="center">Gain insights with up-to-the-minute data and reports.</Text>
+            </Stack>
+          </SimpleGrid>
+        </Container>
+      </Box>
+
+      <Box py={20} px={4} bg="white" id="about">
+        <Container maxW="4xl" textAlign="center">
+          <Heading size="lg" mb={4}>About Us</Heading>
+          <Text mb={6}>
+            Orbas brings job seekers, freelancers, and employers together. Our mission is to simplify talent discovery
+            and collaboration through intuitive tools and smart automation.
+          </Text>
+          <Image src="/globe.svg" alt="About Orbas" mx="auto" boxSize={{ base: "150px", md: "200px" }} />
+        </Container>
       </Box>
 
       <Box py={20} px={4} bg="gray.50" textAlign="center">
-        <Heading size="lg" mb={6}>What people are saying</Heading>
-        <TestimonialCarousel />
-        <Stack direction="row" spacing={10} justify="center" align="center" mt={10}>
-          <Image src="/next.svg" alt="Partner" boxSize="60px" opacity={0.6} />
-          <Image src="/vercel.svg" alt="Partner" boxSize="60px" opacity={0.6} />
-        </Stack>
+        <Container maxW="6xl">
+          <Heading size="lg" mb={6}>
+            What people are saying
+          </Heading>
+          <TestimonialCarousel />
+          <Stack direction="row" spacing={10} justify="center" align="center" mt={10}>
+            <Image src="/next.svg" alt="Partner" boxSize="60px" opacity={0.6} />
+            <Image src="/vercel.svg" alt="Partner" boxSize="60px" opacity={0.6} />
+          </Stack>
+        </Container>
       </Box>
 
       <Box py={20} px={4} textAlign="center">
-        <Heading size="lg" mb={4}>Ready to get started?</Heading>
-        <Button colorScheme="brand" size="lg" as={NextLink} href="/signup">Join Now</Button>
+        <Container maxW="4xl">
+          <Heading size="lg" mb={4}>Ready to get started?</Heading>
+          <Button colorScheme="brand" size="lg" as={NextLink} href="/signup">
+            Join Now
+          </Button>
+        </Container>
       </Box>
 
-      <Box as="footer" py={10} px={4} bg="gray.800" color="gray.200" textAlign="center">
-        <Stack direction="row" spacing={6} justify="center" mb={4}>
-          <Link as={NextLink} href="#">Privacy Policy</Link>
-          <Link as={NextLink} href="#">Terms of Service</Link>
-          <Link as={NextLink} href="#">Help Center</Link>
-        </Stack>
-        <Text fontSize="sm">© {new Date().getFullYear()} Orbas</Text>
+      <Box as="footer" py={10} px={4} bg="gray.800" color="gray.200">
+        <Container maxW="6xl" textAlign="center">
+          <Image src="/next.svg" alt="Orbas logo" mx="auto" mb={4} boxSize="50px" />
+          <Stack direction="row" spacing={6} justify="center" mb={4}>
+            <Link as={NextLink} href="#">
+              Home
+            </Link>
+            <Link as={NextLink} href="#features">
+              Features
+            </Link>
+            <Link as={NextLink} href="#about">
+              About
+            </Link>
+            <Link as={NextLink} href="#">
+              Contact
+            </Link>
+            <Link as={NextLink} href="#">
+              Privacy
+            </Link>
+            <Link as={NextLink} href="#">
+              Terms
+            </Link>
+          </Stack>
+          <Text fontSize="sm">© {new Date().getFullYear()} Orbas</Text>
+        </Container>
       </Box>
     </Box>
   );

--- a/app/signup/documents/page.tsx
+++ b/app/signup/documents/page.tsx
@@ -1,7 +1,17 @@
 "use client";
 
 import { useState } from "react";
-import { Box, Input, Stack, Heading, Button, Textarea, Progress } from "@chakra-ui/react";
+import {
+  Box,
+  Input,
+  Stack,
+  Heading,
+  Button,
+  Textarea,
+  Progress,
+  Alert,
+  AlertIcon,
+} from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { useSignup } from "@/components/SignupContext";
 import styles from "./page.module.css";
@@ -10,6 +20,8 @@ export default function DocumentsPage() {
   const { data, setData } = useSignup();
   const [resume, setResume] = useState<string>(data.resume || "");
   const [coverLetter, setCoverLetter] = useState(data.coverLetter || "");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
   const router = useRouter();
 
   const handleResume = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -21,14 +33,27 @@ export default function DocumentsPage() {
   };
 
   const handleSubmit = async () => {
-    const payload = { ...data, resume, coverLetter };
-    setData({ resume, coverLetter });
-    const res = await fetch("/api/register", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
-    if (res.ok) router.push("/login");
+    setSubmitting(true);
+    setError("");
+    try {
+      const payload = { ...data, resume, coverLetter };
+      setData({ resume, coverLetter });
+      const res = await fetch("/api/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const { error: message } = await res.json();
+        setError(message || "Registration failed");
+        return;
+      }
+      router.push("/login");
+    } catch (e) {
+      setError("Registration failed");
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   const canSubmit = !!resume;
@@ -48,9 +73,24 @@ export default function DocumentsPage() {
         Step 3 of 3
       </Heading>
       <Stack spacing={4}>
+        {error && (
+          <Alert status="error">
+            <AlertIcon />
+            {error}
+          </Alert>
+        )}
         <Input type="file" accept=".pdf,.doc,.docx" onChange={handleResume} />
-        <Textarea placeholder="Cover Letter" value={coverLetter} onChange={(e) => setCoverLetter(e.target.value)} />
-        <Button colorScheme="brand" onClick={handleSubmit} isDisabled={!canSubmit}>
+        <Textarea
+          placeholder="Cover Letter"
+          value={coverLetter}
+          onChange={(e) => setCoverLetter(e.target.value)}
+        />
+        <Button
+          colorScheme="brand"
+          onClick={handleSubmit}
+          isDisabled={!canSubmit || submitting}
+          isLoading={submitting}
+        >
           Submit
         </Button>
       </Stack>


### PR DESCRIPTION
## Summary
- add submission feedback and error handling to final signup step
- ensure registration API returns 201 and logs failures
- polish login form and landing page with nav links, About section, and improved footer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68953cd4cde08320a7258198471f35ee