### PR TITLE
feat: add profile editing interface

### DIFF
--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getUserProfile, updateUserProfile } from "@/lib/services/userService";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const user = await getUserProfile(session.user.email);
+  return NextResponse.json(user);
+}
+
+export async function PUT(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const data = await req.json();
+  const updated = await updateUserProfile(session.user.email, data);
+  return NextResponse.json(updated);
+}

--- a/app/profile/edit/page.module.css
+++ b/app/profile/edit/page.module.css
@@ -1,0 +1,8 @@
+.container {
+  max-width: 600px;
+  margin: 2rem auto;
+  background: white;
+  padding: 2rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 0 10px rgba(0,0,0,0.05);
+}

--- a/app/profile/edit/page.tsx
+++ b/app/profile/edit/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState, useEffect, FormEvent } from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  Stack,
+} from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import api from "@/lib/api";
+import styles from "./page.module.css";
+
+interface ProfileForm {
+  name: string;
+  phone: string;
+  location: string;
+  bio: string;
+  title: string;
+}
+
+export default function EditProfilePage() {
+  const { status } = useSession();
+  const router = useRouter();
+  const [form, setForm] = useState<ProfileForm>({
+    name: "",
+    phone: "",
+    location: "",
+    bio: "",
+    title: "",
+  });
+
+  useEffect(() => {
+    if (status === "unauthenticated") router.push("/login");
+    if (status === "authenticated") {
+      api.get<ProfileForm>("/profile").then((data) => setForm(data));
+    }
+  }, [status, router]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    await api.put("/profile", form);
+    router.push("/profile");
+  };
+
+  return (
+    <Box className={styles.container}>
+      <form onSubmit={handleSubmit}>
+        <Stack spacing={4}>
+          <FormControl>
+            <FormLabel>Name</FormLabel>
+            <Input name="name" value={form.name} onChange={handleChange} />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Title</FormLabel>
+            <Input name="title" value={form.title} onChange={handleChange} />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Phone</FormLabel>
+            <Input name="phone" value={form.phone} onChange={handleChange} />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Location</FormLabel>
+            <Input name="location" value={form.location} onChange={handleChange} />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Bio</FormLabel>
+            <Textarea name="bio" value={form.bio} onChange={handleChange} />
+          </FormControl>
+          <Button type="submit" colorScheme="brand">
+            Save Changes
+          </Button>
+        </Stack>
+      </form>
+    </Box>
+  );
+}

--- a/app/profile/page.module.css
+++ b/app/profile/page.module.css
@@ -1,0 +1,8 @@
+.container {
+  max-width: 400px;
+  margin: 2rem auto;
+  background: white;
+  padding: 2rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 0 10px rgba(0,0,0,0.05);
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,6 +1,8 @@
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
-import { Avatar, Box, Heading, Text, Stack } from "@chakra-ui/react";
+import { Avatar, Box, Heading, Text, Stack, Button } from "@chakra-ui/react";
+import Link from "next/link";
+import styles from "./page.module.css";
 import { authOptions } from "../../lib/auth";
 
 export default async function ProfilePage() {
@@ -8,11 +10,14 @@ export default async function ProfilePage() {
   if (!session || !session.user) redirect("/login");
   const { user } = session;
   return (
-    <Box maxW="md" mx="auto" mt={10} p={6} bg="white" shadow="md" borderRadius="lg">
+    <Box className={styles.container}>
       <Stack spacing={4} align="center">
         <Avatar name={user?.name || "User"} src={user?.image || undefined} size="xl" />
         <Heading size="md">{user?.name}</Heading>
         <Text>{user?.email}</Text>
+        <Button as={Link} href="/profile/edit" colorScheme="brand">
+          Edit Profile
+        </Button>
       </Stack>
     </Box>
   );

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -46,6 +46,9 @@ export default function Navbar() {
             <MenuItem as={Link} href="/profile">
               Profile
             </MenuItem>
+            <MenuItem as={Link} href="/profile/edit">
+              Edit Profile
+            </MenuItem>
             <MenuItem onClick={() => signOut()}>Logout</MenuItem>
           </MenuList>
         </Menu>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -10,6 +10,7 @@ export default function Sidebar() {
   const links = [
     { href: "/dashboard", label: "Dashboard" },
     { href: "/profile", label: "Profile" },
+    { href: "/profile/edit", label: "Edit Profile" },
   ];
 
   return (

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -19,6 +19,8 @@ export const api = {
   get: <T>(path: string, init?: RequestInit) => request<T>(path, init),
   post: <T>(path: string, body: any, init?: RequestInit) =>
     request<T>(path, { ...init, method: "POST", body: JSON.stringify(body) }),
+  put: <T>(path: string, body: any, init?: RequestInit) =>
+    request<T>(path, { ...init, method: "PUT", body: JSON.stringify(body) }),
 };
 
 export default api;

--- a/lib/services/userService.ts
+++ b/lib/services/userService.ts
@@ -1,0 +1,43 @@
+import prisma from "@/lib/prisma";
+
+export async function getUserProfile(email: string) {
+  return prisma.user.findUnique({
+    where: { email },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      phone: true,
+      location: true,
+      bio: true,
+      title: true,
+      image: true,
+    },
+  });
+}
+
+export interface UpdateProfileData {
+  name?: string;
+  phone?: string;
+  location?: string;
+  bio?: string;
+  title?: string;
+  image?: string;
+}
+
+export async function updateUserProfile(email: string, data: UpdateProfileData) {
+  return prisma.user.update({
+    where: { email },
+    data,
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      phone: true,
+      location: true,
+      bio: true,
+      title: true,
+      image: true,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add REST endpoints and service for profile retrieval and update
- build profile editing form with Chakra UI and CSS modules
- expose edit profile link in navigation components

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68953d13154483209ac383c1f27ecb61