### PR TITLE
feat: capture intro video in onboarding

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -17,6 +17,7 @@ export async function POST(req: Request) {
       portfolio: data.portfolio,
       title: data.title,
       image: data.image,
+      introVideo: data.introVideo,
       resume: data.resume,
       coverLetter: data.coverLetter,
     });

--- a/app/profile/page.module.css
+++ b/app/profile/page.module.css
@@ -2,9 +2,8 @@
   background-color: white;
 }
 
-.videoPreview {
+.video {
   width: 100%;
-  max-height: 200px;
-  margin-top: 0.5rem;
   border-radius: 8px;
+  margin-top: 1rem;
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -2,17 +2,25 @@ import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import { Avatar, Box, Heading, Text, Stack } from "@chakra-ui/react";
 import { authOptions } from "../../lib/auth";
+import prisma from "@/lib/prisma";
+import styles from "./page.module.css";
 
 export default async function ProfilePage() {
   const session = await getServerSession(authOptions);
   if (!session || !session.user) redirect("/login");
-  const { user } = session;
+  const dbUser = await prisma.user.findUnique({ where: { email: session.user.email as string } });
+  if (!dbUser) redirect("/login");
   return (
-    <Box maxW="md" mx="auto" mt={10} p={6} bg="white" shadow="md" borderRadius="lg">
+    <Box maxW="md" mx="auto" mt={10} p={6} className={styles.container} shadow="md" borderRadius="lg">
       <Stack spacing={4} align="center">
-        <Avatar name={user?.name || "User"} src={user?.image || undefined} size="xl" />
-        <Heading size="md">{user?.name}</Heading>
-        <Text>{user?.email}</Text>
+        <Avatar name={dbUser.name || "User"} src={dbUser.image || undefined} size="xl" />
+        <Heading size="md">{dbUser.name}</Heading>
+        <Text>{dbUser.email}</Text>
+        {dbUser.introVideo && (
+          <Box w="full">
+            <video src={dbUser.introVideo} className={styles.video} controls />
+          </Box>
+        )}
       </Stack>
     </Box>
   );

--- a/app/signup/financial/page.tsx
+++ b/app/signup/financial/page.tsx
@@ -15,6 +15,7 @@ export default function FinancialPage() {
     portfolio: data.portfolio || "",
     title: data.title || "",
     image: data.image || "",
+    introVideo: data.introVideo || "",
   });
 
   const router = useRouter();
@@ -34,6 +35,16 @@ export default function FinancialPage() {
     reader.readAsDataURL(file);
   };
 
+  const handleVideo = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      setForm((prev) => ({ ...prev, introVideo: reader.result as string }));
+    };
+    reader.readAsDataURL(file);
+  };
+
   const canSubmit = form.payment && form.title;
 
   const handleNext = () => {
@@ -44,6 +55,7 @@ export default function FinancialPage() {
       portfolio: form.portfolio,
       title: form.title,
       image: form.image,
+      introVideo: form.introVideo,
     });
     router.push("/signup/documents");
   };
@@ -66,6 +78,14 @@ export default function FinancialPage() {
         <Input placeholder="Payment Method" name="payment" value={form.payment} onChange={handleChange} />
         <Input placeholder="Tax ID (optional)" name="tax" value={form.tax} onChange={handleChange} />
         <Input type="file" accept="image/*" name="picture" onChange={handleImage} />
+        <Input type="file" accept="video/*" name="introVideo" onChange={handleVideo} />
+        {form.introVideo && (
+          <video
+            src={form.introVideo}
+            className={styles.videoPreview}
+            controls
+          />
+        )}
         <Textarea placeholder="Bio (250 chars)" name="bio" value={form.bio} onChange={handleChange} maxLength={250} />
         <Input placeholder="Portfolio Link" name="portfolio" value={form.portfolio} onChange={handleChange} />
         <Input placeholder="Profile Title" name="title" value={form.title} onChange={handleChange} />

--- a/components/SignupContext.tsx
+++ b/components/SignupContext.tsx
@@ -15,6 +15,7 @@ export type SignupData = {
   portfolio?: string;
   title?: string;
   image?: string;
+  introVideo?: string;
   resume?: string;
   coverLetter?: string;
 };

--- a/lib/controllers/authController.ts
+++ b/lib/controllers/authController.ts
@@ -13,6 +13,7 @@ export async function register(data: {
   portfolio?: string;
   title?: string;
   image?: string;
+  introVideo?: string;
   resume?: string;
   coverLetter?: string;
 }) {

--- a/lib/services/authService.ts
+++ b/lib/services/authService.ts
@@ -18,6 +18,7 @@ export async function registerUser(data: {
   portfolio?: string;
   title?: string;
   image?: string;
+  introVideo?: string;
   resume?: string;
   coverLetter?: string;
 }) {
@@ -38,6 +39,7 @@ export async function registerUser(data: {
       portfolio: data.portfolio,
       title: data.title,
       image: data.image,
+      introVideo: data.introVideo,
       resume: data.resume,
       coverLetter: data.coverLetter,
     },

--- a/prisma/migrations/20250207000002_add_intro_video/migration.sql
+++ b/prisma/migrations/20250207000002_add_intro_video/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "User" ADD COLUMN "introVideo" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,8 +21,10 @@ model User {
   portfolio   String?
   title       String?
   image       String?
+  introVideo  String?
   resume      String?
   coverLetter String?
+  projects    Project[]
 }
 
 model Testimonial {


### PR DESCRIPTION
## Summary
- allow users to upload an introductory video during onboarding
- store intro video in database and surface it on the profile page
- add migration for new introVideo column and fix schema relation

## Testing
- `npm run lint`
- `npx prisma migrate dev --name add_intro_video --create-only` *(fails: Can't reach database server at `localhost:5432`)*


------
https://chatgpt.com/codex/tasks/task_e_68953d04df9c83209475d6ff3502304d