### PR TITLE
feat: add notification center

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -14,6 +14,7 @@ import {
   Th,
   Td,
   TableCaption,
+  VStack,
 } from "@chakra-ui/react";
 import DashboardCard from "@/components/DashboardCard";
 import LineChart from "@/components/LineChart";
@@ -33,13 +34,22 @@ interface Project {
   status: string;
 }
 
+interface Notification {
+  id: number;
+  title: string;
+  message: string;
+  read: boolean;
+}
+
 export default function DashboardPage() {
   const [users, setUsers] = useState<User[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
+  const [notifications, setNotifications] = useState<Notification[]>([]);
 
   useEffect(() => {
     api.get<User[]>("/users").then(setUsers).catch(console.error);
     api.get<Project[]>("/projects").then(setProjects).catch(console.error);
+    api.get<Notification[]>("/notifications").then(setNotifications).catch(console.error);
   }, []);
 
   return (
@@ -91,6 +101,15 @@ export default function DashboardPage() {
           </Table>
         </DashboardCard>
       </SimpleGrid>
+
+      <DashboardCard title="Recent Notifications">
+        <VStack align="stretch">
+          {notifications.slice(0, 3).map((n) => (
+            <Box key={n.id}>{n.title}</Box>
+          ))}
+          {notifications.length === 0 && <Box>No notifications</Box>}
+        </VStack>
+      </DashboardCard>
 
       <DashboardCard title="Projects">
         <Table variant="simple">

--- a/app/(dashboard)/notifications/page.module.css
+++ b/app/(dashboard)/notifications/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  width: 100%;
+}

--- a/app/(dashboard)/notifications/page.tsx
+++ b/app/(dashboard)/notifications/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Heading, Box } from "@chakra-ui/react";
+import api from "@/lib/api";
+import NotificationList, { Notification } from "@/components/NotificationList";
+import styles from "./page.module.css";
+
+export default function NotificationsPage() {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+
+  const load = () => {
+    api
+      .get<Notification[]>("/notifications")
+      .then(setNotifications)
+      .catch(console.error);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const markRead = async (id: number) => {
+    try {
+      await api.patch(`/notifications/${id}`, { read: true });
+      load();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <Box className={styles.container}>
+      <Heading mb={4}>Notifications</Heading>
+      <NotificationList notifications={notifications} onMarkRead={markRead} />
+    </Box>
+  );
+}

--- a/app/api/notifications/[id]/route.ts
+++ b/app/api/notifications/[id]/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import prisma from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+
+export async function PATCH(
+  req: Request,
+  { params }: any
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const user = await prisma.user.findUnique({ where: { email: session.user.email } });
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+  const id = parseInt(params.id, 10);
+  const notification = await prisma.notification.findFirst({
+    where: { id, userId: user.id },
+  });
+  if (!notification) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const body = await req.json().catch(() => ({}));
+  const updated = await prisma.notification.update({
+    where: { id },
+    data: { read: body.read ?? true },
+  });
+  return NextResponse.json(updated);
+}

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import prisma from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const user = await prisma.user.findUnique({ where: { email: session.user.email } });
+  if (!user) {
+    return NextResponse.json([], { status: 200 });
+  }
+  const notifications = await prisma.notification.findMany({
+    where: { userId: user.id },
+    orderBy: { createdAt: "desc" },
+  });
+  return NextResponse.json(notifications);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const user = await prisma.user.findUnique({ where: { email: session.user.email } });
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+  const { title, message } = await req.json();
+  if (!title || !message) {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+  const notification = await prisma.notification.create({
+    data: { userId: user.id, title, message },
+  });
+  return NextResponse.json(notification, { status: 201 });
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -16,6 +16,7 @@ import {
 import Link from "next/link";
 import { signOut, useSession, signIn } from "next-auth/react";
 import styles from "./Navbar.module.css";
+import NotificationBell from "./NotificationBell";
 
 export default function Navbar() {
   const { data: session } = useSession();
@@ -38,17 +39,20 @@ export default function Navbar() {
       </HStack>
       <Input maxW="400px" placeholder="Search" borderRadius="full" bg="gray.100" />
       {session ? (
-        <Menu>
-          <MenuButton>
-            <Avatar name={session.user?.name || "User"} src={session.user?.image || undefined} size="sm" />
-          </MenuButton>
-          <MenuList>
-            <MenuItem as={Link} href="/profile">
-              Profile
-            </MenuItem>
-            <MenuItem onClick={() => signOut()}>Logout</MenuItem>
-          </MenuList>
-        </Menu>
+        <HStack spacing={4}>
+          <NotificationBell />
+          <Menu>
+            <MenuButton>
+              <Avatar name={session.user?.name || "User"} src={session.user?.image || undefined} size="sm" />
+            </MenuButton>
+            <MenuList>
+              <MenuItem as={Link} href="/profile">
+                Profile
+              </MenuItem>
+              <MenuItem onClick={() => signOut()}>Logout</MenuItem>
+            </MenuList>
+          </Menu>
+        </HStack>
       ) : (
         <Button colorScheme="brand" onClick={() => signIn()}>
           Login

--- a/components/NotificationBell.module.css
+++ b/components/NotificationBell.module.css
@@ -1,0 +1,9 @@
+.container {
+  position: relative;
+}
+
+.badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+}

--- a/components/NotificationBell.tsx
+++ b/components/NotificationBell.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { IconButton, Badge, Box } from "@chakra-ui/react";
+import { FiBell } from "react-icons/fi";
+import Link from "next/link";
+import api from "@/lib/api";
+import styles from "./NotificationBell.module.css";
+
+interface Notification {
+  id: number;
+  read: boolean;
+}
+
+export default function NotificationBell() {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    api
+      .get<Notification[]>("/notifications")
+      .then((data) => {
+        setCount(data.filter((n) => !n.read).length);
+      })
+      .catch(console.error);
+  }, []);
+
+  return (
+    <Box position="relative" className={styles.container}>
+      <IconButton
+        as={Link}
+        href="/notifications"
+        aria-label="Notifications"
+        icon={<FiBell />}
+        variant="ghost"
+      />
+      {count > 0 && (
+        <Badge className={styles.badge} colorScheme="red" borderRadius="full">
+          {count}
+        </Badge>
+      )}
+    </Box>
+  );
+}

--- a/components/NotificationList.module.css
+++ b/components/NotificationList.module.css
@@ -1,0 +1,11 @@
+.list {
+  width: 100%;
+}
+
+.item {
+  transition: background 0.2s;
+}
+
+.item:hover {
+  background: #f9f9f9;
+}

--- a/components/NotificationList.tsx
+++ b/components/NotificationList.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { VStack, Box, Text, HStack, Button, Badge } from "@chakra-ui/react";
+import styles from "./NotificationList.module.css";
+
+export interface Notification {
+  id: number;
+  title: string;
+  message: string;
+  read: boolean;
+  createdAt: string;
+}
+
+interface Props {
+  notifications: Notification[];
+  onMarkRead: (id: number) => void;
+}
+
+export default function NotificationList({ notifications, onMarkRead }: Props) {
+  return (
+    <VStack spacing={4} align="stretch" className={styles.list}>
+      {notifications.map((n) => (
+        <Box key={n.id} p={4} bg="white" borderRadius="md" shadow="sm" className={styles.item}>
+          <HStack justify="space-between" align="start">
+            <Box>
+              <Text fontWeight="bold">{n.title}</Text>
+              <Text>{n.message}</Text>
+            </Box>
+            <HStack>
+              {!n.read && <Badge colorScheme="blue">New</Badge>}
+              {!n.read && (
+                <Button size="sm" onClick={() => onMarkRead(n.id)}>
+                  Mark read
+                </Button>
+              )}
+            </HStack>
+          </HStack>
+        </Box>
+      ))}
+    </VStack>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -10,6 +10,7 @@ export default function Sidebar() {
   const links = [
     { href: "/dashboard", label: "Dashboard" },
     { href: "/profile", label: "Profile" },
+    { href: "/notifications", label: "Notifications" },
   ];
 
   return (

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -19,6 +19,8 @@ export const api = {
   get: <T>(path: string, init?: RequestInit) => request<T>(path, init),
   post: <T>(path: string, body: any, init?: RequestInit) =>
     request<T>(path, { ...init, method: "POST", body: JSON.stringify(body) }),
+  patch: <T>(path: string, body: any, init?: RequestInit) =>
+    request<T>(path, { ...init, method: "PATCH", body: JSON.stringify(body) }),
 };
 
 export default api;

--- a/prisma/migrations/20250207000002_add_notifications/migration.sql
+++ b/prisma/migrations/20250207000002_add_notifications/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "public"."Notification" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "read" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Notification_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "Notification_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,8 @@ model User {
   image       String?
   resume      String?
   coverLetter String?
+  notifications Notification[]
+  projects      Project[]
 }
 
 model Testimonial {
@@ -38,5 +40,15 @@ model Project {
   owner     User     @relation(fields: [ownerId], references: [id])
   ownerId   Int
   status    String
+  createdAt DateTime @default(now())
+}
+
+model Notification {
+  id        Int      @id @default(autoincrement())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    Int
+  title     String
+  message   String
+  read      Boolean  @default(false)
   createdAt DateTime @default(now())
 }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -48,6 +48,14 @@ async function main() {
       ],
       skipDuplicates: true,
     });
+
+    await prisma.notification.createMany({
+      data: [
+        { userId: admin.id, title: 'Welcome', message: 'Thanks for joining the platform!' },
+        { userId: admin.id, title: 'Project Update', message: 'Your project "Neon Launch" has a new milestone.' },
+      ],
+      skipDuplicates: true,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- add Notification model and seed data
- expose notification API for fetching and marking read
- build Notification Center UI and integrate with navbar, sidebar, and dashboard

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68953d20012c8320a231da673c871685