### PR TITLE
feat: add profile onboarding wizard

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -14,7 +14,9 @@ import {
   Th,
   Td,
   TableCaption,
+  Button,
 } from "@chakra-ui/react";
+import Link from "next/link";
 import DashboardCard from "@/components/DashboardCard";
 import LineChart from "@/components/LineChart";
 import api from "@/lib/api";
@@ -44,6 +46,9 @@ export default function DashboardPage() {
 
   return (
     <Box className={styles.container}>
+      <Button as={Link} href="/onboarding" colorScheme="brand" mb={4}>
+        Complete Onboarding
+      </Button>
       <SimpleGrid columns={{ base: 1, md: 3 }} spacing={6} mb={10}>
         <DashboardCard title="Users">
           <Stat>

--- a/app/(dashboard)/onboarding/documents/page.module.css
+++ b/app/(dashboard)/onboarding/documents/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  background-color: white;
+}

--- a/app/(dashboard)/onboarding/documents/page.tsx
+++ b/app/(dashboard)/onboarding/documents/page.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Input,
+  Stack,
+  Heading,
+  Textarea,
+  Progress,
+  Button,
+  Alert,
+  AlertIcon,
+} from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import api from "@/lib/api";
+import { useOnboarding } from "@/components/OnboardingContext";
+import styles from "./page.module.css";
+
+export default function DocumentsOnboardingPage() {
+  const { data, setData } = useOnboarding();
+  const [resume, setResume] = useState<string>(data.resume || "");
+  const [coverLetter, setCoverLetter] = useState(data.coverLetter || "");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const router = useRouter();
+
+  const handleResume = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => setResume(reader.result as string);
+    reader.readAsDataURL(file);
+  };
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    setError("");
+    try {
+      const payload = { ...data, resume, coverLetter };
+      setData({ resume, coverLetter });
+      await api.put("/profile", payload);
+      router.push("/dashboard");
+    } catch (e) {
+      setError("Onboarding failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const canSubmit = !!resume;
+
+  return (
+    <Box
+      maxW="lg"
+      mx="auto"
+      mt={10}
+      p={6}
+      className={styles.container}
+      shadow="md"
+      borderRadius="lg"
+    >
+      <Progress value={100} mb={6} />
+      <Heading size="md" mb={6} textAlign="center">
+        Onboarding - Step 3 of 3
+      </Heading>
+      <Stack spacing={4}>
+        {error && (
+          <Alert status="error">
+            <AlertIcon />
+            {error}
+          </Alert>
+        )}
+        <Input type="file" accept=".pdf,.doc,.docx" onChange={handleResume} />
+        <Textarea
+          placeholder="Cover Letter"
+          value={coverLetter}
+          onChange={(e) => setCoverLetter(e.target.value)}
+        />
+        <Button
+          colorScheme="brand"
+          onClick={handleSubmit}
+          isDisabled={!canSubmit || submitting}
+          isLoading={submitting}
+        >
+          Finish
+        </Button>
+      </Stack>
+    </Box>
+  );
+}
+

--- a/app/(dashboard)/onboarding/financial/page.module.css
+++ b/app/(dashboard)/onboarding/financial/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  background-color: white;
+}

--- a/app/(dashboard)/onboarding/financial/page.tsx
+++ b/app/(dashboard)/onboarding/financial/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Input,
+  Stack,
+  Heading,
+  Textarea,
+  Progress,
+  Button,
+} from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import { useOnboarding } from "@/components/OnboardingContext";
+import styles from "./page.module.css";
+
+export default function FinancialOnboardingPage() {
+  const { data, setData } = useOnboarding();
+  const [form, setForm] = useState({
+    payment: data.payment || "",
+    taxId: data.taxId || "",
+    bio: data.bio || "",
+    portfolio: data.portfolio || "",
+    title: data.title || "",
+    image: data.image || "",
+  });
+  const router = useRouter();
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleImage = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      setForm((prev) => ({ ...prev, image: reader.result as string }));
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const canSubmit = form.payment && form.title;
+
+  const handleNext = () => {
+    setData(form);
+    router.push("/onboarding/documents");
+  };
+
+  return (
+    <Box
+      maxW="lg"
+      mx="auto"
+      mt={10}
+      p={6}
+      className={styles.container}
+      shadow="md"
+      borderRadius="lg"
+    >
+      <Progress value={66} mb={6} />
+      <Heading size="md" mb={6} textAlign="center">
+        Onboarding - Step 2 of 3
+      </Heading>
+      <Stack spacing={4}>
+        <Input
+          placeholder="Payment Method"
+          name="payment"
+          value={form.payment}
+          onChange={handleChange}
+        />
+        <Input
+          placeholder="Tax ID (optional)"
+          name="taxId"
+          value={form.taxId}
+          onChange={handleChange}
+        />
+        <Input type="file" accept="image/*" onChange={handleImage} />
+        <Textarea
+          placeholder="Bio (250 chars)"
+          name="bio"
+          value={form.bio}
+          onChange={handleChange}
+          maxLength={250}
+        />
+        <Input
+          placeholder="Portfolio Link"
+          name="portfolio"
+          value={form.portfolio}
+          onChange={handleChange}
+        />
+        <Input
+          placeholder="Profile Title"
+          name="title"
+          value={form.title}
+          onChange={handleChange}
+        />
+        <Button onClick={handleNext} colorScheme="brand" isDisabled={!canSubmit}>
+          Next
+        </Button>
+      </Stack>
+    </Box>
+  );
+}
+

--- a/app/(dashboard)/onboarding/layout.tsx
+++ b/app/(dashboard)/onboarding/layout.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { OnboardingProvider } from "@/components/OnboardingContext";
+
+export default function OnboardingLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <OnboardingProvider>{children}</OnboardingProvider>;
+}
+

--- a/app/(dashboard)/onboarding/page.module.css
+++ b/app/(dashboard)/onboarding/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  background-color: white;
+}

--- a/app/(dashboard)/onboarding/page.tsx
+++ b/app/(dashboard)/onboarding/page.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Input,
+  Stack,
+  Heading,
+  Textarea,
+  Progress,
+  Button,
+} from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import api from "@/lib/api";
+import { useOnboarding } from "@/components/OnboardingContext";
+import styles from "./page.module.css";
+
+interface ProfileForm {
+  name: string;
+  phone: string;
+  location: string;
+  bio: string;
+  expertise: string;
+}
+
+export default function OnboardingPage() {
+  const { data, setData } = useOnboarding();
+  const [form, setForm] = useState<ProfileForm>({
+    name: data.name || "",
+    phone: data.phone || "",
+    location: data.location || "",
+    bio: data.bio || "",
+    expertise: data.expertise || "",
+  });
+  const router = useRouter();
+
+  useEffect(() => {
+    api
+      .get<ProfileForm>("/profile")
+      .then((res) =>
+        setForm((prev) => ({
+          ...prev,
+          ...res,
+        }))
+      )
+      .catch(() => {});
+  }, []);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleNext = () => {
+    setData(form);
+    router.push("/onboarding/financial");
+  };
+
+  const canSubmit = form.name && form.phone && form.location;
+
+  return (
+    <Box
+      maxW="lg"
+      mx="auto"
+      mt={10}
+      p={6}
+      className={styles.container}
+      shadow="md"
+      borderRadius="lg"
+    >
+      <Progress value={33} mb={6} />
+      <Heading size="md" mb={6} textAlign="center">
+        Onboarding - Step 1 of 3
+      </Heading>
+      <Stack spacing={4}>
+        <Input
+          placeholder="Full Name"
+          name="name"
+          value={form.name}
+          onChange={handleChange}
+        />
+        <Input
+          placeholder="Phone Number"
+          name="phone"
+          value={form.phone}
+          onChange={handleChange}
+        />
+        <Input
+          placeholder="Location"
+          name="location"
+          value={form.location}
+          onChange={handleChange}
+        />
+        <Textarea
+          placeholder="Professional Bio"
+          name="bio"
+          value={form.bio}
+          onChange={handleChange}
+        />
+        <Input
+          placeholder="Areas of Expertise (optional)"
+          name="expertise"
+          value={form.expertise}
+          onChange={handleChange}
+        />
+        <Button onClick={handleNext} colorScheme="brand" isDisabled={!canSubmit}>
+          Next
+        </Button>
+      </Stack>
+    </Box>
+  );
+}
+

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -46,6 +46,9 @@ export default function Navbar() {
             <MenuItem as={Link} href="/profile">
               Profile
             </MenuItem>
+            <MenuItem as={Link} href="/onboarding">
+              Onboarding
+            </MenuItem>
             <MenuItem as={Link} href="/profile/edit">
               Edit Profile
             </MenuItem>

--- a/components/OnboardingContext.tsx
+++ b/components/OnboardingContext.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { createContext, useContext, useState } from "react";
+
+export type OnboardingData = {
+  name?: string;
+  phone?: string;
+  location?: string;
+  bio?: string;
+  expertise?: string;
+  payment?: string;
+  taxId?: string;
+  portfolio?: string;
+  title?: string;
+  image?: string;
+  resume?: string;
+  coverLetter?: string;
+};
+
+interface OnboardingContextValue {
+  data: OnboardingData;
+  setData: (values: Partial<OnboardingData>) => void;
+}
+
+const OnboardingContext = createContext<OnboardingContextValue | undefined>(
+  undefined
+);
+
+export function OnboardingProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [data, setDataState] = useState<OnboardingData>({});
+
+  const setData = (values: Partial<OnboardingData>) => {
+    setDataState((prev) => ({ ...prev, ...values }));
+  };
+
+  return (
+    <OnboardingContext.Provider value={{ data, setData }}>
+      {children}
+    </OnboardingContext.Provider>
+  );
+}
+
+export function useOnboarding() {
+  const context = useContext(OnboardingContext);
+  if (!context) {
+    throw new Error("useOnboarding must be used within OnboardingProvider");
+  }
+  return context;
+}
+

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -9,6 +9,7 @@ export default function Sidebar() {
   const pathname = usePathname();
   const links = [
     { href: "/dashboard", label: "Dashboard" },
+    { href: "/onboarding", label: "Onboarding" },
     { href: "/profile", label: "Profile" },
     { href: "/profile/edit", label: "Edit Profile" },
   ];

--- a/lib/services/userService.ts
+++ b/lib/services/userService.ts
@@ -10,8 +10,14 @@ export async function getUserProfile(email: string) {
       phone: true,
       location: true,
       bio: true,
+      expertise: true,
+      payment: true,
+      taxId: true,
+      portfolio: true,
       title: true,
       image: true,
+      resume: true,
+      coverLetter: true,
     },
   });
 }
@@ -21,8 +27,14 @@ export interface UpdateProfileData {
   phone?: string;
   location?: string;
   bio?: string;
+  expertise?: string;
+  payment?: string;
+  taxId?: string;
+  portfolio?: string;
   title?: string;
   image?: string;
+  resume?: string;
+  coverLetter?: string;
 }
 
 export async function updateUserProfile(email: string, data: UpdateProfileData) {
@@ -36,8 +48,14 @@ export async function updateUserProfile(email: string, data: UpdateProfileData) 
       phone: true,
       location: true,
       bio: true,
+      expertise: true,
+      payment: true,
+      taxId: true,
+      portfolio: true,
       title: true,
       image: true,
+      resume: true,
+      coverLetter: true,
     },
   });
 }


### PR DESCRIPTION
## Summary
- add OnboardingContext and multi-step onboarding pages for personal, financial, and document setup
- expose onboarding access in navigation and dashboard
- expand user service to handle full profile data

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68953eec6ee4832090f9f005fd0862d0