### PR TITLE
feat: add searchable user directory

### DIFF
--- a/app/(dashboard)/search/page.module.css
+++ b/app/(dashboard)/search/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  padding: 1rem;
+}

--- a/app/(dashboard)/search/page.tsx
+++ b/app/(dashboard)/search/page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  SimpleGrid,
+  Avatar,
+  Text,
+  VStack,
+  HStack,
+} from "@chakra-ui/react";
+import api from "@/lib/api";
+import styles from "./page.module.css";
+
+interface User {
+  id: number;
+  name: string | null;
+  email: string;
+  location: string | null;
+  expertise: string | null;
+  image: string | null;
+}
+
+export default function SearchPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const [query, setQuery] = useState(searchParams.get("q") || "");
+  const [location, setLocation] = useState(searchParams.get("location") || "");
+  const [expertise, setExpertise] = useState(searchParams.get("expertise") || "");
+  const [results, setResults] = useState<User[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const performSearch = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (query) params.set("q", query);
+      if (location) params.set("location", location);
+      if (expertise) params.set("expertise", expertise);
+      const data = await api.get<User[]>(`/search?${params.toString()}`);
+      setResults(data);
+      router.replace(`/search?${params.toString()}`);
+    } catch (err: any) {
+      setError(err.message || "Search failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (searchParams.toString()) {
+      performSearch();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <Box className={styles.container}>
+      <VStack as="form" spacing={4} align="stretch" onSubmit={(e) => e.preventDefault()}>
+        <HStack spacing={4} flexWrap="wrap">
+          <FormControl maxW="300px">
+            <FormLabel>Query</FormLabel>
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search users"
+            />
+          </FormControl>
+          <FormControl maxW="200px">
+            <FormLabel>Location</FormLabel>
+            <Input value={location} onChange={(e) => setLocation(e.target.value)} />
+          </FormControl>
+          <FormControl maxW="200px">
+            <FormLabel>Expertise</FormLabel>
+            <Input value={expertise} onChange={(e) => setExpertise(e.target.value)} />
+          </FormControl>
+          <Button
+            colorScheme="brand"
+            onClick={performSearch}
+            isLoading={loading}
+            alignSelf="flex-end"
+          >
+            Search
+          </Button>
+        </HStack>
+      </VStack>
+      {error && (
+        <Text color="red.500" mt={4}>
+          {error}
+        </Text>
+      )}
+      <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4} mt={6}>
+        {results.map((user) => (
+          <HStack key={user.id} p={4} borderWidth="1px" borderRadius="md" bg="white">
+            <Avatar name={user.name || user.email} src={user.image || undefined} />
+            <Box>
+              <Text fontWeight="bold">{user.name || "Unnamed"}</Text>
+              <Text fontSize="sm" color="gray.600">
+                {user.email}
+              </Text>
+              {user.location && (
+                <Text fontSize="sm" color="gray.600">
+                  {user.location}
+                </Text>
+              )}
+              {user.expertise && (
+                <Text fontSize="sm" color="gray.600">
+                  {user.expertise}
+                </Text>
+              )}
+            </Box>
+          </HStack>
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get("q") || "";
+  const location = searchParams.get("location") || undefined;
+  const expertise = searchParams.get("expertise") || undefined;
+
+  const users = await prisma.user.findMany({
+    where: {
+      AND: [
+        q
+          ? {
+              OR: [
+                { name: { contains: q, mode: "insensitive" } },
+                { email: { contains: q, mode: "insensitive" } },
+                { bio: { contains: q, mode: "insensitive" } },
+              ],
+            }
+          : {},
+        location
+          ? { location: { equals: location, mode: "insensitive" } }
+          : {},
+        expertise
+          ? { expertise: { contains: expertise, mode: "insensitive" } }
+          : {},
+      ],
+    },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      location: true,
+      expertise: true,
+      image: true,
+    },
+    take: 50,
+  });
+
+  return NextResponse.json(users);
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -15,10 +15,20 @@ import {
 } from "@chakra-ui/react";
 import Link from "next/link";
 import { signOut, useSession, signIn } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 import styles from "./Navbar.module.css";
 
 export default function Navbar() {
   const { data: session } = useSession();
+  const router = useRouter();
+  const [term, setTerm] = useState("");
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && term.trim()) {
+      router.push(`/search?q=${encodeURIComponent(term.trim())}`);
+    }
+  };
 
   return (
     <Flex
@@ -36,7 +46,15 @@ export default function Navbar() {
         <Image src="/next.svg" alt="Logo" boxSize="32px" />
         <Box className={styles.brand}>MyDashboard</Box>
       </HStack>
-      <Input maxW="400px" placeholder="Search" borderRadius="full" bg="gray.100" />
+      <Input
+        maxW="400px"
+        placeholder="Search"
+        borderRadius="full"
+        bg="gray.100"
+        value={term}
+        onChange={(e) => setTerm(e.target.value)}
+        onKeyDown={handleKeyDown}
+      />
       {session ? (
         <Menu>
           <MenuButton>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -9,6 +9,7 @@ export default function Sidebar() {
   const pathname = usePathname();
   const links = [
     { href: "/dashboard", label: "Dashboard" },
+    { href: "/search", label: "Search" },
     { href: "/profile", label: "Profile" },
     { href: "/profile/edit", label: "Edit Profile" },
   ];


### PR DESCRIPTION
## Summary
- add backend search API with query, location, and expertise filters
- build Chakra UI search page to display user results
- link search into navbar and sidebar for easy access

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68953fe512508320a7ab8ba42a0f62e2