### PR TITLE
feat: add notification center UI

### DIFF
--- a/app/(dashboard)/notifications/page.module.css
+++ b/app/(dashboard)/notifications/page.module.css
@@ -1,0 +1,4 @@
+.container {
+  width: 100%;
+}
+

--- a/app/(dashboard)/notifications/page.tsx
+++ b/app/(dashboard)/notifications/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { VStack, Heading } from "@chakra-ui/react";
+import NotificationItem from "@/components/NotificationItem";
+import styles from "./page.module.css";
+import type { NotificationItemProps } from "@/components/NotificationItem";
+
+export default function NotificationsPage() {
+  const [notifications, setNotifications] = useState<NotificationItemProps[]>([]);
+
+  useEffect(() => {
+    fetch("/api/notifications")
+      .then((res) => res.json())
+      .then((data) => setNotifications(data))
+      .catch((err) => console.error("Failed to load notifications", err));
+  }, []);
+
+  const markRead = async (id: number) => {
+    await fetch("/api/notifications", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ notificationId: id }),
+    });
+    setNotifications((prev) =>
+      prev.map((n) => (n.id === id ? { ...n, read: true } : n))
+    );
+  };
+
+  return (
+    <VStack align="stretch" spacing={4} className={styles.container}>
+      <Heading size="lg">Notifications</Heading>
+      {notifications.map((n) => (
+        <NotificationItem key={n.id} {...n} onRead={markRead} />
+      ))}
+    </VStack>
+  );
+}
+

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import {
+  getUserNotifications,
+  markNotificationRead,
+} from "@/lib/services/notificationService";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  const id = session?.user?.id ? Number(session.user.id) : undefined;
+  if (!id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const notifications = await getUserNotifications(id);
+  return NextResponse.json(notifications);
+}
+
+export async function PATCH(req: Request) {
+  const session = await getServerSession(authOptions);
+  const id = session?.user?.id ? Number(session.user.id) : undefined;
+  if (!id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { notificationId } = await req.json();
+  if (!notificationId) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+  await markNotificationRead(Number(notificationId), id);
+  return NextResponse.json({ success: true });
+}
+

--- a/components/NotificationItem.module.css
+++ b/components/NotificationItem.module.css
@@ -1,0 +1,4 @@
+.item {
+  transition: background-color 0.2s ease;
+}
+

--- a/components/NotificationItem.tsx
+++ b/components/NotificationItem.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Box, HStack, Text, Badge } from "@chakra-ui/react";
+import styles from "./NotificationItem.module.css";
+
+export interface NotificationItemProps {
+  id: number;
+  message: string;
+  read: boolean;
+  createdAt: string;
+  onRead?: (id: number) => void;
+}
+
+export default function NotificationItem({
+  id,
+  message,
+  read,
+  createdAt,
+  onRead,
+}: NotificationItemProps) {
+  return (
+    <Box
+      p={4}
+      bg={read ? "gray.100" : "white"}
+      borderWidth="1px"
+      borderRadius="md"
+      className={styles.item}
+      onClick={() => !read && onRead?.(id)}
+      cursor={read ? "default" : "pointer"}
+    >
+      <HStack justify="space-between">
+        <Text>{message}</Text>
+        {!read && <Badge colorScheme="blue">New</Badge>}
+      </HStack>
+      <Text fontSize="sm" color="gray.500" mt={2}>
+        {new Date(createdAt).toLocaleString()}
+      </Text>
+    </Box>
+  );
+}
+

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -11,6 +11,7 @@ export default function Sidebar() {
     { href: "/dashboard", label: "Dashboard" },
     { href: "/profile", label: "Profile" },
     { href: "/profile/edit", label: "Edit Profile" },
+    { href: "/notifications", label: "Notifications" },
   ];
 
   return (

--- a/lib/services/notificationService.ts
+++ b/lib/services/notificationService.ts
@@ -1,0 +1,24 @@
+import prisma from "@/lib/prisma";
+
+export async function getUserNotifications(userId: number) {
+  return prisma.notification.findMany({
+    where: { userId },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+export async function markNotificationRead(id: number, userId: number) {
+  return prisma.notification.updateMany({
+    where: { id, userId },
+    data: { read: true },
+  });
+}
+
+export async function createNotification(userId: number, message: string) {
+  return prisma.notification.create({
+    data: { userId, message },
+  });
+}
+
+export type Notification = Awaited<ReturnType<typeof getUserNotifications>>[number];
+

--- a/prisma/migrations/20250207000002_add_notifications/migration.sql
+++ b/prisma/migrations/20250207000002_add_notifications/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "Notification" (
+    "id" SERIAL PRIMARY KEY,
+    "userId" INTEGER NOT NULL REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    "message" TEXT NOT NULL,
+    "read" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,8 @@ model User {
   image       String?
   resume      String?
   coverLetter String?
+  notifications Notification[]
+  projects      Project[]
 }
 
 model Testimonial {
@@ -38,5 +40,14 @@ model Project {
   owner     User     @relation(fields: [ownerId], references: [id])
   ownerId   Int
   status    String
+  createdAt DateTime @default(now())
+}
+
+model Notification {
+  id        Int      @id @default(autoincrement())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    Int
+  message   String
+  read      Boolean  @default(false)
   createdAt DateTime @default(now())
 }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -48,6 +48,14 @@ async function main() {
       ],
       skipDuplicates: true,
     });
+
+    await prisma.notification.createMany({
+      data: [
+        { userId: admin.id, message: 'Welcome to Orbas, Admin!' },
+        { userId: admin.id, message: 'Your dashboard has been updated.' },
+      ],
+      skipDuplicates: true,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- add Prisma model and seed data for notifications
- expose `/api/notifications` with read tracking
- build dashboard notifications page and sidebar link

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68953ff0808883208ea32a1344faddcf