### PR TITLE
Add notification center UI with backend support

### DIFF
--- a/app/(dashboard)/notifications/page.module.css
+++ b/app/(dashboard)/notifications/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  padding: 1rem;
+}

--- a/app/(dashboard)/notifications/page.tsx
+++ b/app/(dashboard)/notifications/page.tsx
@@ -1,0 +1,12 @@
+import { Heading } from "@chakra-ui/react";
+import NotificationList from "@/components/NotificationList";
+import styles from "./page.module.css";
+
+export default function NotificationsPage() {
+  return (
+    <div className={styles.container}>
+      <Heading mb={4}>Notifications</Heading>
+      <NotificationList />
+    </div>
+  );
+}

--- a/app/api/notifications/[id]/route.ts
+++ b/app/api/notifications/[id]/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse, NextRequest } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { markNotificationRead } from "@/lib/services/notificationService";
+
+export async function PUT(_req: NextRequest, context: any) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const id = Number(context?.params?.id);
+  if (Number.isNaN(id)) {
+    return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+  }
+  await markNotificationRead(id, session.user.email);
+  return NextResponse.json({ success: true });
+}

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getUserNotifications } from "@/lib/services/notificationService";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const notifications = await getUserNotifications(session.user.email);
+  return NextResponse.json(notifications);
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -16,6 +16,7 @@ import {
 import Link from "next/link";
 import { signOut, useSession, signIn } from "next-auth/react";
 import styles from "./Navbar.module.css";
+import NotificationBell from "./NotificationBell";
 
 export default function Navbar() {
   const { data: session } = useSession();
@@ -38,20 +39,23 @@ export default function Navbar() {
       </HStack>
       <Input maxW="400px" placeholder="Search" borderRadius="full" bg="gray.100" />
       {session ? (
-        <Menu>
-          <MenuButton>
-            <Avatar name={session.user?.name || "User"} src={session.user?.image || undefined} size="sm" />
-          </MenuButton>
-          <MenuList>
-            <MenuItem as={Link} href="/profile">
-              Profile
-            </MenuItem>
-            <MenuItem as={Link} href="/profile/edit">
-              Edit Profile
-            </MenuItem>
-            <MenuItem onClick={() => signOut()}>Logout</MenuItem>
-          </MenuList>
-        </Menu>
+        <HStack spacing={4} align="center">
+          <NotificationBell />
+          <Menu>
+            <MenuButton>
+              <Avatar name={session.user?.name || "User"} src={session.user?.image || undefined} size="sm" />
+            </MenuButton>
+            <MenuList>
+              <MenuItem as={Link} href="/profile">
+                Profile
+              </MenuItem>
+              <MenuItem as={Link} href="/profile/edit">
+                Edit Profile
+              </MenuItem>
+              <MenuItem onClick={() => signOut()}>Logout</MenuItem>
+            </MenuList>
+          </Menu>
+        </HStack>
       ) : (
         <Button colorScheme="brand" onClick={() => signIn()}>
           Login

--- a/components/NotificationBell.module.css
+++ b/components/NotificationBell.module.css
@@ -1,0 +1,5 @@
+.badge {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+}

--- a/components/NotificationBell.tsx
+++ b/components/NotificationBell.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { IconButton, Box, Link as ChakraLink } from "@chakra-ui/react";
+import NextLink from "next/link";
+import { FiBell } from "react-icons/fi";
+import { useEffect, useState } from "react";
+import styles from "./NotificationBell.module.css";
+
+export default function NotificationBell() {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch("/api/notifications");
+        if (res.ok) {
+          const data = await res.json();
+          setCount(data.filter((n: any) => !n.read).length);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <ChakraLink as={NextLink} href="/notifications" position="relative">
+      <IconButton
+        aria-label="Notifications"
+        icon={<FiBell />}
+        variant="ghost"
+        size="md"
+      />
+      {count > 0 && (
+        <Box
+          className={styles.badge}
+          bg="red.500"
+          color="white"
+          borderRadius="full"
+          px={2}
+          fontSize="xs"
+        >
+          {count}
+        </Box>
+      )}
+    </ChakraLink>
+  );
+}

--- a/components/NotificationList.module.css
+++ b/components/NotificationList.module.css
@@ -1,0 +1,9 @@
+.list {
+  width: 100%;
+}
+.item {
+  transition: background 0.2s ease;
+}
+.item:hover {
+  background: #f7fafc;
+}

--- a/components/NotificationList.tsx
+++ b/components/NotificationList.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { VStack, Box, Text, Button } from "@chakra-ui/react";
+import styles from "./NotificationList.module.css";
+import { formatDateTime } from "@/lib/utils/time";
+
+interface Notification {
+  id: number;
+  message: string;
+  type: string;
+  read: boolean;
+  createdAt: string;
+}
+
+export default function NotificationList() {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch("/api/notifications");
+      if (res.ok) {
+        const data = await res.json();
+        setNotifications(data);
+      }
+    }
+    load();
+  }, []);
+
+  const markRead = async (id: number) => {
+    const res = await fetch(`/api/notifications/${id}`, { method: "PUT" });
+    if (res.ok) {
+      setNotifications((prev) =>
+        prev.map((n) => (n.id === id ? { ...n, read: true } : n))
+      );
+    }
+  };
+
+  return (
+    <VStack spacing={4} align="stretch" className={styles.list}>
+      {notifications.map((n) => (
+        <Box
+          key={n.id}
+          p={4}
+          borderWidth="1px"
+          borderRadius="md"
+          bg={n.read ? "gray.100" : "white"}
+          className={styles.item}
+        >
+          <Text fontWeight="medium" mb={1}>
+            {n.message}
+          </Text>
+          <Text fontSize="sm" color="gray.600" mb={2}>
+            {formatDateTime(n.createdAt)}
+          </Text>
+          {!n.read && (
+            <Button size="sm" onClick={() => markRead(n.id)} colorScheme="brand">
+              Mark as read
+            </Button>
+          )}
+        </Box>
+      ))}
+    </VStack>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -11,6 +11,7 @@ export default function Sidebar() {
     { href: "/dashboard", label: "Dashboard" },
     { href: "/profile", label: "Profile" },
     { href: "/profile/edit", label: "Edit Profile" },
+    { href: "/notifications", label: "Notifications" },
   ];
 
   return (

--- a/lib/services/notificationService.ts
+++ b/lib/services/notificationService.ts
@@ -1,0 +1,15 @@
+import prisma from "@/lib/prisma";
+
+export async function getUserNotifications(email: string) {
+  return prisma.notification.findMany({
+    where: { user: { email } },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+export async function markNotificationRead(id: number, email: string) {
+  return prisma.notification.updateMany({
+    where: { id, user: { email } },
+    data: { read: true },
+  });
+}

--- a/lib/utils/time.ts
+++ b/lib/utils/time.ts
@@ -1,0 +1,3 @@
+export function formatDateTime(date: string | number | Date) {
+  return new Date(date).toLocaleString();
+}

--- a/prisma/migrations/20250207000002_add_notifications/migration.sql
+++ b/prisma/migrations/20250207000002_add_notifications/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "public"."Notification" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "message" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "read" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Notification_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "Notification_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,8 @@ model User {
   image       String?
   resume      String?
   coverLetter String?
+  notifications Notification[]
+  projects      Project[]
 }
 
 model Testimonial {
@@ -38,5 +40,15 @@ model Project {
   owner     User     @relation(fields: [ownerId], references: [id])
   ownerId   Int
   status    String
+  createdAt DateTime @default(now())
+}
+
+model Notification {
+  id        Int      @id @default(autoincrement())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    Int
+  message   String
+  type      String
+  read      Boolean  @default(false)
   createdAt DateTime @default(now())
 }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -40,6 +40,8 @@ async function main() {
   });
 
   const admin = await prisma.user.findUnique({ where: { email: 'admin@example.com' } });
+  const alice = await prisma.user.findUnique({ where: { email: 'alice@example.com' } });
+  const bob = await prisma.user.findUnique({ where: { email: 'bob@example.com' } });
   if (admin) {
     await prisma.project.createMany({
       data: [
@@ -49,6 +51,16 @@ async function main() {
       skipDuplicates: true,
     });
   }
+
+  await prisma.notification.createMany({
+    data: [
+      { userId: admin?.id, message: 'Welcome to Orbas!', type: 'system' },
+      { userId: admin?.id, message: 'Project "Neon Launch" updated.', type: 'project' },
+      { userId: alice?.id, message: 'Your profile was viewed.', type: 'profile' },
+      { userId: bob?.id, message: 'You received a new testimonial.', type: 'social' },
+    ].filter((n) => n.userId),
+    skipDuplicates: true,
+  });
 }
 
 main()


### PR DESCRIPTION
## Summary
- add Prisma Notification model and seed data
- expose notification API to fetch and mark read
- build Chakra UI notification center and bell integrated into dashboard

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68953fcf7684832096daf240c6717a8a