### PR TITLE
Run Prisma migrations during Vercel build

### DIFF
--- a/prisma/baseline.js
+++ b/prisma/baseline.js
@@ -1,5 +1,22 @@
 const { execSync } = require('child_process');
 
+function deployMigrations() {
+  // Only run in production-like environments where a database URL is provided
+  if (
+    !(process.env.VERCEL || process.env.NODE_ENV === 'production') ||
+    !process.env.DATABASE_URL
+  ) {
+    console.log('Skipping prisma migrate deploy');
+    return;
+  }
+
+  try {
+    execSync('npx prisma migrate deploy', { stdio: 'inherit' });
+  } catch (error) {
+    console.error('Failed to deploy migrations', error);
+  }
+}
+
 function resetDatabase() {
   // Avoid running reset in environments where a database connection
   // isn't expected (e.g. production, CI or missing env vars)
@@ -28,5 +45,6 @@ function generateClient() {
   }
 }
 
+deployMigrations();
 resetDatabase();
 generateClient();


### PR DESCRIPTION
## Summary
- add deploy step to baseline script so Prisma migrations run automatically on Vercel builds

## Testing
- `npm run lint`
- `VERCEL=1 DATABASE_URL="postgres://user:pass@localhost:5432/db" node prisma/baseline.js` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_6895410285d08320b884edd7a7353e57