### PR TITLE
feat: add gig browsing page

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -15,6 +15,7 @@ import {
   Td,
   TableCaption,
   Button,
+  HStack,
 } from "@chakra-ui/react";
 import Link from "next/link";
 import DashboardCard from "@/components/DashboardCard";
@@ -46,9 +47,14 @@ export default function DashboardPage() {
 
   return (
     <Box className={styles.container}>
-      <Button as={Link} href="/onboarding" colorScheme="brand" mb={4}>
-        Complete Onboarding
-      </Button>
+      <HStack spacing={4} mb={4}>
+        <Button as={Link} href="/onboarding" colorScheme="brand">
+          Complete Onboarding
+        </Button>
+        <Button as={Link} href="/gigs" colorScheme="brand" variant="outline">
+          Browse Gigs
+        </Button>
+      </HStack>
       <SimpleGrid columns={{ base: 1, md: 3 }} spacing={6} mb={10}>
         <DashboardCard title="Users">
           <Stat>

--- a/app/(dashboard)/gigs/page.module.css
+++ b/app/(dashboard)/gigs/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  padding: 1rem;
+}

--- a/app/(dashboard)/gigs/page.tsx
+++ b/app/(dashboard)/gigs/page.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  NumberInput,
+  NumberInputField,
+  Select,
+  SimpleGrid,
+  VStack,
+  HStack,
+  Spinner,
+  Text,
+  Heading,
+} from "@chakra-ui/react";
+import api from "@/lib/api";
+import GigCard, { Gig } from "@/components/GigCard";
+import styles from "./page.module.css";
+
+export default function GigBrowsePage() {
+  const [search, setSearch] = useState("");
+  const [category, setCategory] = useState("");
+  const [minPrice, setMinPrice] = useState("");
+  const [maxPrice, setMaxPrice] = useState("");
+  const [sort, setSort] = useState("newest");
+  const [gigs, setGigs] = useState<Gig[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const loadGigs = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const params = new URLSearchParams();
+      if (search) params.set("search", search);
+      if (category) params.set("category", category);
+      if (minPrice) params.set("minPrice", minPrice);
+      if (maxPrice) params.set("maxPrice", maxPrice);
+      if (sort) params.set("sort", sort);
+      const data = await api.get<Gig[]>(`/gigs?${params.toString()}`);
+      setGigs(data);
+    } catch (err: any) {
+      setError(err.message || "Failed to load gigs");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadGigs();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sort]);
+
+  return (
+    <Box className={styles.container}>
+      <VStack as="form" spacing={4} align="stretch" onSubmit={(e) => e.preventDefault()}>
+        <HStack spacing={4} flexWrap="wrap">
+          <FormControl maxW="300px">
+            <FormLabel>Search</FormLabel>
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search gigs"
+            />
+          </FormControl>
+          <FormControl maxW="200px">
+            <FormLabel>Category</FormLabel>
+            <Input value={category} onChange={(e) => setCategory(e.target.value)} />
+          </FormControl>
+          <FormControl maxW="150px">
+            <FormLabel>Min Price</FormLabel>
+            <NumberInput min={0} value={minPrice} onChange={(v) => setMinPrice(v)}>
+              <NumberInputField />
+            </NumberInput>
+          </FormControl>
+          <FormControl maxW="150px">
+            <FormLabel>Max Price</FormLabel>
+            <NumberInput min={0} value={maxPrice} onChange={(v) => setMaxPrice(v)}>
+              <NumberInputField />
+            </NumberInput>
+          </FormControl>
+          <FormControl maxW="200px">
+            <FormLabel>Sort By</FormLabel>
+            <Select value={sort} onChange={(e) => setSort(e.target.value)}>
+              <option value="newest">Newest</option>
+              <option value="price">Lowest Price</option>
+              <option value="rating">Highest Rating</option>
+            </Select>
+          </FormControl>
+          <Button colorScheme="brand" alignSelf="flex-end" onClick={loadGigs}>
+            Apply
+          </Button>
+        </HStack>
+      </VStack>
+      {error && (
+        <Text color="red.500" mt={4}>
+          {error}
+        </Text>
+      )}
+      {loading ? (
+        <Spinner mt={8} />
+      ) : (
+        <>
+          <SimpleGrid columns={{ base: 1, sm: 2, md: 3 }} spacing={4} mt={6}>
+            {gigs.map((gig) => (
+              <GigCard key={gig.id} gig={gig} />
+            ))}
+          </SimpleGrid>
+          {gigs.filter((g) => g.rating && g.rating >= 4.7).length > 0 && (
+            <>
+              <Heading size="md" mt={10} mb={4}>
+                Recommended for You
+              </Heading>
+              <SimpleGrid columns={{ base: 1, sm: 2, md: 3 }} spacing={4}>
+                {gigs
+                  .filter((g) => g.rating && g.rating >= 4.7)
+                  .map((gig) => (
+                    <GigCard key={`rec-${gig.id}`} gig={gig} />
+                  ))}
+              </SimpleGrid>
+            </>
+          )}
+        </>
+      )}
+    </Box>
+  );
+}

--- a/app/api/gigs/route.ts
+++ b/app/api/gigs/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getGigs, createGig } from "@/lib/services/gigService";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const filters = {
+    search: searchParams.get("search") || undefined,
+    category: searchParams.get("category") || undefined,
+    minPrice: searchParams.get("minPrice")
+      ? Number(searchParams.get("minPrice"))
+      : undefined,
+    maxPrice: searchParams.get("maxPrice")
+      ? Number(searchParams.get("maxPrice"))
+      : undefined,
+    sort: (searchParams.get("sort") as "price" | "rating" | "newest") || undefined,
+  };
+  const gigs = await getGigs(filters);
+  return NextResponse.json(gigs);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  const sellerId = session?.user?.id ? Number(session.user.id) : undefined;
+  if (!sellerId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { title, description, price, category, thumbnail } = await req.json();
+  if (!title || !description || typeof price !== "number") {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+  }
+  const gig = await createGig({
+    title,
+    description,
+    price,
+    category,
+    thumbnail,
+    sellerId,
+  });
+  return NextResponse.json(gig, { status: 201 });
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -3,6 +3,7 @@
 import { ChakraProvider } from "@chakra-ui/react";
 import { SessionProvider } from "next-auth/react";
 import theme from "../theme";
+import { FavoritesProvider } from "@/components/FavoritesContext";
 
 export function Providers({
   children,
@@ -11,7 +12,9 @@ export function Providers({
 }) {
   return (
     <SessionProvider>
-      <ChakraProvider theme={theme}>{children}</ChakraProvider>
+      <ChakraProvider theme={theme}>
+        <FavoritesProvider>{children}</FavoritesProvider>
+      </ChakraProvider>
     </SessionProvider>
   );
 }

--- a/components/FavoritesContext.tsx
+++ b/components/FavoritesContext.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from "react";
+import { Gig } from "./GigCard";
+
+interface FavoritesContextValue {
+  favorites: Gig[];
+  toggleFavorite: (gig: Gig) => void;
+  isFavorite: (id: number) => boolean;
+}
+
+const FavoritesContext = createContext<FavoritesContextValue | undefined>(undefined);
+
+export function FavoritesProvider({ children }: { children: ReactNode }) {
+  const [favorites, setFavorites] = useState<Gig[]>([]);
+
+  const toggleFavorite = (gig: Gig) => {
+    setFavorites((prev) =>
+      prev.find((g) => g.id === gig.id)
+        ? prev.filter((g) => g.id !== gig.id)
+        : [...prev, gig]
+    );
+  };
+
+  const isFavorite = (id: number) => favorites.some((g) => g.id === id);
+
+  return (
+    <FavoritesContext.Provider value={{ favorites, toggleFavorite, isFavorite }}>
+      {children}
+    </FavoritesContext.Provider>
+  );
+}
+
+export function useFavorites() {
+  const ctx = useContext(FavoritesContext);
+  if (!ctx) throw new Error("useFavorites must be used within FavoritesProvider");
+  return ctx;
+}

--- a/components/GigCard.module.css
+++ b/components/GigCard.module.css
@@ -1,0 +1,7 @@
+.card {
+  transition: box-shadow 0.2s ease;
+}
+
+.card:hover {
+  box-shadow: var(--chakra-shadows-md);
+}

--- a/components/GigCard.tsx
+++ b/components/GigCard.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Box, Image, Text, HStack, Icon, VStack, IconButton } from "@chakra-ui/react";
+import { StarIcon } from "@chakra-ui/icons";
+import { FaHeart } from "react-icons/fa";
+import styles from "./GigCard.module.css";
+import { formatCurrency } from "@/lib/utils/format";
+import { useFavorites } from "@/components/FavoritesContext";
+
+export interface Gig {
+  id: number;
+  title: string;
+  price: number;
+  category?: string | null;
+  thumbnail?: string | null;
+  rating?: number | null;
+  seller: { name: string | null };
+}
+
+export default function GigCard({ gig }: { gig: Gig }) {
+  const { toggleFavorite, isFavorite } = useFavorites();
+  const stars = Array.from({ length: 5 }, (_, i) => (
+    <Icon
+      as={StarIcon}
+      key={i}
+      color={gig.rating && gig.rating > i ? "yellow.400" : "gray.300"}
+    />
+  ));
+
+  return (
+    <Box
+      borderWidth="1px"
+      borderRadius="md"
+      overflow="hidden"
+      bg="white"
+      position="relative"
+      className={styles.card}
+    >
+      <IconButton
+        aria-label="favorite"
+        icon={<FaHeart />}
+        position="absolute"
+        top={2}
+        right={2}
+        variant="ghost"
+        color={isFavorite(gig.id) ? "red.500" : "gray.300"}
+        onClick={() => toggleFavorite(gig)}
+      />
+      {gig.thumbnail && (
+        <Image
+          src={gig.thumbnail}
+          alt={gig.title}
+          w="100%"
+          h="160px"
+          objectFit="cover"
+        />
+      )}
+      <VStack align="start" p={4} spacing={1}>
+        <Text fontWeight="bold">{gig.title}</Text>
+        {gig.category && (
+          <Text color="gray.600" fontSize="sm">
+            {gig.category}
+          </Text>
+        )}
+        <HStack spacing={1}>{stars}</HStack>
+        <Text fontSize="lg" color="brand.500" fontWeight="bold">
+          {formatCurrency(gig.price)}
+        </Text>
+        <Text fontSize="sm" color="gray.500">
+          by {gig.seller.name}
+        </Text>
+      </VStack>
+    </Box>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -14,6 +14,7 @@ export default function Sidebar() {
     { href: "/profile", label: "Profile" },
     { href: "/profile/edit", label: "Edit Profile" },
     { href: "/notifications", label: "Notifications" },
+    { href: "/gigs", label: "Browse Gigs" },
   ];
 
   return (

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -21,6 +21,8 @@ export const api = {
     request<T>(path, { ...init, method: "POST", body: JSON.stringify(body) }),
   put: <T>(path: string, body: any, init?: RequestInit) =>
     request<T>(path, { ...init, method: "PUT", body: JSON.stringify(body) }),
+  delete: <T>(path: string, init?: RequestInit) =>
+    request<T>(path, { ...init, method: "DELETE" }),
 };
 
 export default api;

--- a/lib/services/gigService.ts
+++ b/lib/services/gigService.ts
@@ -1,0 +1,48 @@
+import prisma from "@/lib/prisma";
+
+export interface GigFilters {
+  search?: string;
+  category?: string;
+  minPrice?: number;
+  maxPrice?: number;
+  sort?: "price" | "rating" | "newest";
+}
+
+export async function getGigs(filters: GigFilters = {}) {
+  const { search, category, minPrice, maxPrice, sort } = filters;
+  const orderBy =
+    sort === "price"
+      ? { price: "asc" }
+      : sort === "rating"
+      ? { rating: "desc" }
+      : { createdAt: "desc" };
+
+  return prisma.gig.findMany({
+    where: {
+      ...(search ? { title: { contains: search, mode: "insensitive" } } : {}),
+      ...(category ? { category } : {}),
+      ...(minPrice || maxPrice
+        ? { price: { gte: minPrice || 0, lte: maxPrice || undefined } }
+        : {}),
+    },
+    include: {
+      seller: {
+        select: { id: true, name: true, image: true },
+      },
+    },
+    orderBy,
+  });
+}
+
+export interface CreateGigData {
+  title: string;
+  description: string;
+  price: number;
+  category?: string;
+  thumbnail?: string;
+  sellerId: number;
+}
+
+export async function createGig(data: CreateGigData) {
+  return prisma.gig.create({ data });
+}

--- a/lib/utils/format.ts
+++ b/lib/utils/format.ts
@@ -1,0 +1,7 @@
+export function formatCurrency(amount: number): string {
+  return amount.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+  });
+}

--- a/prisma/migrations/20250207000003_add_gigs/migration.sql
+++ b/prisma/migrations/20250207000003_add_gigs/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "Gig" (
+    "id" SERIAL PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "price" INTEGER NOT NULL,
+    "category" TEXT,
+    "thumbnail" TEXT,
+    "rating" DOUBLE PRECISION,
+    "sellerId" INTEGER NOT NULL REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,7 @@ model User {
   coverLetter String?
   notifications Notification[]
   projects      Project[]
+  gigs         Gig[]
 }
 
 model Testimonial {
@@ -50,4 +51,17 @@ model Notification {
   message   String
   read      Boolean  @default(false)
   createdAt DateTime @default(now())
+}
+
+model Gig {
+  id          Int      @id @default(autoincrement())
+  title       String
+  description String
+  price       Int
+  category    String?
+  thumbnail   String?
+  rating      Float?
+  seller      User     @relation(fields: [sellerId], references: [id])
+  sellerId    Int
+  createdAt   DateTime @default(now())
 }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -56,6 +56,36 @@ async function main() {
       ],
       skipDuplicates: true,
     });
+
+    await prisma.gig.createMany({
+      data: [
+        {
+          title: 'Logo Design',
+          description: 'Professional logo design for your brand',
+          price: 100,
+          category: 'Design',
+          sellerId: admin.id,
+          rating: 4.8,
+        },
+        {
+          title: 'Website Development',
+          description: 'Responsive website built with modern technologies',
+          price: 500,
+          category: 'Development',
+          sellerId: admin.id,
+          rating: 4.5,
+        },
+        {
+          title: 'SEO Audit',
+          description: 'Comprehensive SEO analysis and recommendations',
+          price: 200,
+          category: 'Marketing',
+          sellerId: admin.id,
+          rating: 4.7,
+        },
+      ],
+      skipDuplicates: true,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- add Prisma Gig model with sample data and migrations
- implement gigs API with filtering and creation hooks
- build gig browsing UI with search, recommendations, favorites, and navigation integration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run baseline`


------
https://chatgpt.com/codex/tasks/task_e_689541c0e8548320bc3d6b5acc6fb3c5