### PR TITLE
feat: add gig management dashboard

### DIFF
--- a/app/(dashboard)/gigs/page.module.css
+++ b/app/(dashboard)/gigs/page.module.css
@@ -1,0 +1,7 @@
+.container {
+  width: 100%;
+}
+
+.toggle {
+  margin-bottom: 1rem;
+}

--- a/app/(dashboard)/gigs/page.tsx
+++ b/app/(dashboard)/gigs/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, Button, ButtonGroup, Stack } from "@chakra-ui/react";
+import api from "@/lib/api";
+import GigCard from "@/components/GigCard";
+import OrderCard from "@/components/OrderCard";
+import { Gig, Order } from "@/lib/services/gigService";
+import styles from "./page.module.css";
+
+export default function GigsPage() {
+  const [mode, setMode] = useState<"seller" | "buyer">("seller");
+  const [gigs, setGigs] = useState<Gig[]>([]);
+  const [orders, setOrders] = useState<Order[]>([]);
+
+  useEffect(() => {
+    if (mode === "seller") {
+      api.get<Gig[]>("/gigs?mode=seller").then(setGigs).catch(console.error);
+    } else {
+      api.get<Order[]>("/gigs?mode=buyer").then(setOrders).catch(console.error);
+    }
+  }, [mode]);
+
+  const handleToggle = async (gig: Gig) => {
+    try {
+      await api.put(`/gigs/${gig.id}`, { active: !gig.active });
+      const updated = await api.get<Gig[]>("/gigs?mode=seller");
+      setGigs(updated);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <Box className={styles.container}>
+      <ButtonGroup className={styles.toggle}>
+        <Button
+          colorScheme={mode === "seller" ? "brand" : "gray"}
+          onClick={() => setMode("seller")}
+        >
+          Gig Seller
+        </Button>
+        <Button
+          colorScheme={mode === "buyer" ? "brand" : "gray"}
+          onClick={() => setMode("buyer")}
+        >
+          Gig Buyer
+        </Button>
+      </ButtonGroup>
+      <Stack spacing={4}>
+        {mode === "seller"
+          ? gigs.map((g) => <GigCard key={g.id} gig={g} onToggle={handleToggle} />)
+          : orders.map((o) => <OrderCard key={o.id} order={o} />)}
+      </Stack>
+    </Box>
+  );
+}

--- a/app/api/gigs/[id]/route.ts
+++ b/app/api/gigs/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { updateGigStatus } from "@/lib/services/gigService";
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = Number(session.user.id);
+  const id = Number(params.id);
+  const data = await req.json();
+  const updated = await updateGigStatus(id, userId, data);
+  return NextResponse.json(updated);
+}

--- a/app/api/gigs/route.ts
+++ b/app/api/gigs/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getSellerGigs, getBuyerOrders } from "@/lib/services/gigService";
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = Number(session.user.id);
+  const { searchParams } = new URL(req.url);
+  const mode = searchParams.get("mode") === "buyer" ? "buyer" : "seller";
+  if (mode === "seller") {
+    const gigs = await getSellerGigs(userId);
+    return NextResponse.json(gigs);
+  }
+  const orders = await getBuyerOrders(userId);
+  return NextResponse.json(orders);
+}

--- a/components/GigCard.module.css
+++ b/components/GigCard.module.css
@@ -1,0 +1,4 @@
+.card {
+  width: 100%;
+  margin-bottom: 1rem;
+}

--- a/components/GigCard.tsx
+++ b/components/GigCard.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Box, HStack, Heading, Text, Button, Stat, StatLabel, StatNumber } from "@chakra-ui/react";
+import styles from "./GigCard.module.css";
+import { Gig } from "@/lib/services/gigService";
+
+interface Props {
+  gig: Gig;
+  onToggle: (gig: Gig) => void;
+}
+
+export default function GigCard({ gig, onToggle }: Props) {
+  return (
+    <Box className={styles.card} borderWidth="1px" borderRadius="md" p={4} bg="white" shadow="sm">
+      <HStack justify="space-between" mb={2}>
+        <Heading size="md">{gig.title}</Heading>
+        <Button size="sm" onClick={() => onToggle(gig)} colorScheme={gig.active ? "red" : "green"}>
+          {gig.active ? "Pause" : "Activate"}
+        </Button>
+      </HStack>
+      <Text mb={2}>Price: ${gig.price.toFixed(2)}</Text>
+      <HStack spacing={4}>
+        <Stat>
+          <StatLabel>Views</StatLabel>
+          <StatNumber>{gig.views}</StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel>Clicks</StatLabel>
+          <StatNumber>{gig.clicks}</StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel>Orders</StatLabel>
+          <StatNumber>{gig.orders}</StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel>Earnings</StatLabel>
+          <StatNumber>${gig.earnings.toFixed(2)}</StatNumber>
+        </Stat>
+      </HStack>
+    </Box>
+  );
+}

--- a/components/OrderCard.module.css
+++ b/components/OrderCard.module.css
@@ -1,0 +1,4 @@
+.card {
+  width: 100%;
+  margin-bottom: 1rem;
+}

--- a/components/OrderCard.tsx
+++ b/components/OrderCard.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Box, Heading, Text, Stat, StatLabel, StatNumber } from "@chakra-ui/react";
+import styles from "./OrderCard.module.css";
+import { Order } from "@/lib/services/gigService";
+
+interface Props {
+  order: Order;
+}
+
+export default function OrderCard({ order }: Props) {
+  return (
+    <Box className={styles.card} borderWidth="1px" borderRadius="md" p={4} bg="white" shadow="sm">
+      <Heading size="md" mb={2}>
+        {order.gig.title}
+      </Heading>
+      <Text mb={2}>Seller: {order.gig.seller?.name}</Text>
+      <Stat>
+        <StatLabel>Status</StatLabel>
+        <StatNumber>{order.status}</StatNumber>
+      </Stat>
+      <Text mt={2}>Price: ${order.price.toFixed(2)}</Text>
+    </Box>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -14,6 +14,7 @@ export default function Sidebar() {
     { href: "/profile", label: "Profile" },
     { href: "/profile/edit", label: "Edit Profile" },
     { href: "/notifications", label: "Notifications" },
+    { href: "/gigs", label: "Gigs" },
   ];
 
   return (

--- a/lib/services/gigService.ts
+++ b/lib/services/gigService.ts
@@ -1,0 +1,37 @@
+import prisma from "@/lib/prisma";
+
+export async function getSellerGigs(userId: number) {
+  return prisma.gig.findMany({
+    where: { sellerId: userId },
+    orderBy: { id: "asc" },
+  });
+}
+
+export async function getBuyerOrders(userId: number) {
+  return prisma.order.findMany({
+    where: { buyerId: userId },
+    include: {
+      gig: {
+        select: {
+          title: true,
+          seller: { select: { name: true } },
+        },
+      },
+    },
+    orderBy: { id: "asc" },
+  });
+}
+
+export async function updateGigStatus(
+  id: number,
+  userId: number,
+  data: { active?: boolean }
+) {
+  return prisma.gig.updateMany({
+    where: { id, sellerId: userId },
+    data,
+  });
+}
+
+export type Gig = Awaited<ReturnType<typeof getSellerGigs>>[number];
+export type Order = Awaited<ReturnType<typeof getBuyerOrders>>[number];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,8 @@ model User {
   coverLetter String?
   notifications Notification[]
   projects      Project[]
+  gigs          Gig[]
+  orders        Order[] @relation("BuyerOrders")
 }
 
 model Testimonial {
@@ -40,6 +42,33 @@ model Project {
   owner     User     @relation(fields: [ownerId], references: [id])
   ownerId   Int
   status    String
+  createdAt DateTime @default(now())
+}
+
+model Gig {
+  id        Int      @id @default(autoincrement())
+  title     String
+  seller    User     @relation(fields: [sellerId], references: [id])
+  sellerId  Int
+  description String?
+  price     Float
+  views     Int      @default(0)
+  clicks    Int      @default(0)
+  orders    Int      @default(0)
+  earnings  Float    @default(0)
+  active    Boolean  @default(true)
+  createdAt DateTime @default(now())
+  ordersList Order[]
+}
+
+model Order {
+  id        Int      @id @default(autoincrement())
+  gig       Gig      @relation(fields: [gigId], references: [id])
+  gigId     Int
+  buyer     User     @relation("BuyerOrders", fields: [buyerId], references: [id])
+  buyerId   Int
+  status    String   @default("pending")
+  price     Float
   createdAt DateTime @default(now())
 }
 

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -57,6 +57,58 @@ async function main() {
       skipDuplicates: true,
     });
   }
+
+  const alice = await prisma.user.findUnique({ where: { email: 'alice@example.com' } });
+  const bob = await prisma.user.findUnique({ where: { email: 'bob@example.com' } });
+  if (alice && bob) {
+    const logoGig = await prisma.gig.upsert({
+      where: { id: 1 },
+      update: {},
+      create: {
+        title: 'Logo Design',
+        sellerId: alice.id,
+        price: 100,
+        views: 10,
+        clicks: 5,
+        orders: 2,
+        earnings: 200,
+      },
+    });
+    const websiteGig = await prisma.gig.upsert({
+      where: { id: 2 },
+      update: {},
+      create: {
+        title: 'Website Build',
+        sellerId: bob.id,
+        price: 500,
+        views: 20,
+        clicks: 10,
+        orders: 1,
+        earnings: 500,
+      },
+    });
+
+    await prisma.order.upsert({
+      where: { id: 1 },
+      update: {},
+      create: {
+        gigId: logoGig.id,
+        buyerId: bob.id,
+        status: 'completed',
+        price: logoGig.price,
+      },
+    });
+    await prisma.order.upsert({
+      where: { id: 2 },
+      update: {},
+      create: {
+        gigId: websiteGig.id,
+        buyerId: alice.id,
+        status: 'pending',
+        price: websiteGig.price,
+      },
+    });
+  }
 }
 
 main()


### PR DESCRIPTION
## Summary
- model gigs and orders in Prisma
- add gig service and API endpoints
- implement seller/buyer gig dashboard with Chakra UI components

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689541d150e48320a72a5348bc31c681