### PR TITLE
feat: enhance notification center with context and badges

### DIFF
--- a/app/(dashboard)/notifications/page.tsx
+++ b/app/(dashboard)/notifications/page.tsx
@@ -1,35 +1,21 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { VStack, Heading } from "@chakra-ui/react";
+import { VStack, Heading, Button } from "@chakra-ui/react";
 import NotificationItem from "@/components/NotificationItem";
 import styles from "./page.module.css";
-import type { NotificationItemProps } from "@/components/NotificationItem";
+import { useNotifications } from "@/components/NotificationContext";
 
 export default function NotificationsPage() {
-  const [notifications, setNotifications] = useState<NotificationItemProps[]>([]);
-
-  useEffect(() => {
-    fetch("/api/notifications")
-      .then((res) => res.json())
-      .then((data) => setNotifications(data))
-      .catch((err) => console.error("Failed to load notifications", err));
-  }, []);
-
-  const markRead = async (id: number) => {
-    await fetch("/api/notifications", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ notificationId: id }),
-    });
-    setNotifications((prev) =>
-      prev.map((n) => (n.id === id ? { ...n, read: true } : n))
-    );
-  };
+  const { notifications, markRead, markAllRead } = useNotifications();
 
   return (
     <VStack align="stretch" spacing={4} className={styles.container}>
       <Heading size="lg">Notifications</Heading>
+      {notifications.length > 0 ? (
+        <Button alignSelf="flex-end" size="sm" onClick={markAllRead}>
+          Mark all as read
+        </Button>
+      ) : null}
       {notifications.map((n) => (
         <NotificationItem key={n.id} {...n} onRead={markRead} />
       ))}

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth";
 import {
   getUserNotifications,
   markNotificationRead,
+  markAllNotificationsRead,
 } from "@/lib/services/notificationService";
 
 export async function GET() {
@@ -22,11 +23,12 @@ export async function PATCH(req: Request) {
   if (!id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
-  const { notificationId } = await req.json();
-  if (!notificationId) {
-    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  const { notificationId } = await req.json().catch(() => ({}));
+  if (notificationId) {
+    await markNotificationRead(Number(notificationId), id);
+  } else {
+    await markAllNotificationsRead(id);
   }
-  await markNotificationRead(Number(notificationId), id);
   return NextResponse.json({ success: true });
 }
 

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -3,6 +3,7 @@
 import { ChakraProvider } from "@chakra-ui/react";
 import { SessionProvider } from "next-auth/react";
 import theme from "../theme";
+import { NotificationProvider } from "@/components/NotificationContext";
 
 export function Providers({
   children,
@@ -11,7 +12,9 @@ export function Providers({
 }) {
   return (
     <SessionProvider>
-      <ChakraProvider theme={theme}>{children}</ChakraProvider>
+      <ChakraProvider theme={theme}>
+        <NotificationProvider>{children}</NotificationProvider>
+      </ChakraProvider>
     </SessionProvider>
   );
 }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -15,6 +15,7 @@ import {
 } from "@chakra-ui/react";
 import Link from "next/link";
 import { signOut, useSession, signIn } from "next-auth/react";
+import NotificationBell from "./NotificationBell";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import styles from "./Navbar.module.css";
@@ -56,23 +57,26 @@ export default function Navbar() {
         onKeyDown={handleKeyDown}
       />
       {session ? (
-        <Menu>
-          <MenuButton>
-            <Avatar name={session.user?.name || "User"} src={session.user?.image || undefined} size="sm" />
-          </MenuButton>
-          <MenuList>
-            <MenuItem as={Link} href="/profile">
-              Profile
-            </MenuItem>
-            <MenuItem as={Link} href="/onboarding">
-              Onboarding
-            </MenuItem>
-            <MenuItem as={Link} href="/profile/edit">
-              Edit Profile
-            </MenuItem>
-            <MenuItem onClick={() => signOut()}>Logout</MenuItem>
-          </MenuList>
-        </Menu>
+        <HStack spacing={4}>
+          <NotificationBell />
+          <Menu>
+            <MenuButton>
+              <Avatar name={session.user?.name || "User"} src={session.user?.image || undefined} size="sm" />
+            </MenuButton>
+            <MenuList>
+              <MenuItem as={Link} href="/profile">
+                Profile
+              </MenuItem>
+              <MenuItem as={Link} href="/onboarding">
+                Onboarding
+              </MenuItem>
+              <MenuItem as={Link} href="/profile/edit">
+                Edit Profile
+              </MenuItem>
+              <MenuItem onClick={() => signOut()}>Logout</MenuItem>
+            </MenuList>
+          </Menu>
+        </HStack>
       ) : (
         <Button colorScheme="brand" onClick={() => signIn()}>
           Login

--- a/components/NotificationBell.module.css
+++ b/components/NotificationBell.module.css
@@ -1,0 +1,6 @@
+.wrapper {
+  display: inline-block;
+}
+.badge {
+  transform: translate(50%, -50%);
+}

--- a/components/NotificationBell.tsx
+++ b/components/NotificationBell.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Box, IconButton, Badge } from "@chakra-ui/react";
+import Link from "next/link";
+import { FiBell } from "react-icons/fi";
+import { useNotifications } from "./NotificationContext";
+import styles from "./NotificationBell.module.css";
+
+export default function NotificationBell() {
+  const { unreadCount } = useNotifications();
+  return (
+    <Box position="relative" className={styles.wrapper}>
+      <IconButton
+        as={Link}
+        href="/notifications"
+        aria-label="Notifications"
+        icon={<FiBell />}
+        variant="ghost"
+      />
+      {unreadCount > 0 && (
+        <Badge
+          colorScheme="red"
+          position="absolute"
+          top="0"
+          right="0"
+          borderRadius="full"
+          className={styles.badge}
+        >
+          {unreadCount}
+        </Badge>
+      )}
+    </Box>
+  );
+}
+

--- a/components/NotificationContext.tsx
+++ b/components/NotificationContext.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+import type { NotificationItemProps } from "@/components/NotificationItem";
+
+interface NotificationContextValue {
+  notifications: NotificationItemProps[];
+  unreadCount: number;
+  markRead: (id: number) => Promise<void>;
+  markAllRead: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const NotificationContext = createContext<NotificationContextValue | undefined>(
+  undefined
+);
+
+export function useNotifications() {
+  const ctx = useContext(NotificationContext);
+  if (!ctx) {
+    throw new Error("useNotifications must be used within NotificationProvider");
+  }
+  return ctx;
+}
+
+export function NotificationProvider({ children }: { children: ReactNode }) {
+  const [notifications, setNotifications] = useState<NotificationItemProps[]>([]);
+
+  const refresh = async () => {
+    try {
+      const res = await fetch("/api/notifications");
+      if (res.ok) {
+        const data: NotificationItemProps[] = await res.json();
+        setNotifications(data);
+      }
+    } catch (e) {
+      console.error("Failed to fetch notifications", e);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const markRead = async (id: number) => {
+    try {
+      await fetch("/api/notifications", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notificationId: id }),
+      });
+      setNotifications((prev) =>
+        prev.map((n) => (n.id === id ? { ...n, read: true } : n))
+      );
+    } catch (e) {
+      console.error("Failed to mark read", e);
+    }
+  };
+
+  const markAllRead = async () => {
+    try {
+      await fetch("/api/notifications", { method: "PATCH" });
+      setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+    } catch (e) {
+      console.error("Failed to mark all read", e);
+    }
+  };
+
+  const value: NotificationContextValue = {
+    notifications,
+    unreadCount: notifications.filter((n) => !n.read).length,
+    markRead,
+    markAllRead,
+    refresh,
+  };
+
+  return (
+    <NotificationContext.Provider value={value}>
+      {children}
+    </NotificationContext.Provider>
+  );
+}
+

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,19 +1,21 @@
 "use client";
 
-import { VStack, Link as ChakraLink } from "@chakra-ui/react";
+import { VStack, Link as ChakraLink, HStack, Badge } from "@chakra-ui/react";
 import NextLink from "next/link";
 import { usePathname } from "next/navigation";
 import styles from "./Sidebar.module.css";
+import { useNotifications } from "./NotificationContext";
 
 export default function Sidebar() {
   const pathname = usePathname();
+  const { unreadCount } = useNotifications();
   const links = [
     { href: "/dashboard", label: "Dashboard" },
     { href: "/search", label: "Search" },
     { href: "/onboarding", label: "Onboarding" },
     { href: "/profile", label: "Profile" },
     { href: "/profile/edit", label: "Edit Profile" },
-    { href: "/notifications", label: "Notifications" },
+    { href: "/notifications", label: "Notifications", badge: unreadCount },
   ];
 
   return (
@@ -39,7 +41,10 @@ export default function Sidebar() {
           _hover={{ bg: "gray.100" }}
           className={`${styles.link} ${pathname === link.href ? styles.active : ""}`}
         >
-          {link.label}
+          <HStack justify="space-between" w="full">
+            <span>{link.label}</span>
+            {link.badge ? <Badge colorScheme="red">{link.badge}</Badge> : null}
+          </HStack>
         </ChakraLink>
       ))}
     </VStack>

--- a/lib/services/notificationService.ts
+++ b/lib/services/notificationService.ts
@@ -14,6 +14,13 @@ export async function markNotificationRead(id: number, userId: number) {
   });
 }
 
+export async function markAllNotificationsRead(userId: number) {
+  return prisma.notification.updateMany({
+    where: { userId, read: false },
+    data: { read: true },
+  });
+}
+
 export async function createNotification(userId: number, message: string) {
   return prisma.notification.create({
     data: { userId, message },


### PR DESCRIPTION
## Summary
- implement NotificationContext to manage user alerts
- add NotificationBell and badge counts in navigation
- support mark-all-read in notifications API and UI

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689542abc24c8320b3da727a7534219d