### PR TITLE
feat: add gig browsing page

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -35,21 +35,32 @@ interface Project {
   status: string;
 }
 
+interface Gig {
+  id: number;
+}
+
 export default function DashboardPage() {
   const [users, setUsers] = useState<User[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
+  const [gigs, setGigs] = useState<Gig[]>([]);
 
   useEffect(() => {
     api.get<User[]>("/users").then(setUsers).catch(console.error);
     api.get<Project[]>("/projects").then(setProjects).catch(console.error);
+    api.get<Gig[]>("/gigs").then(setGigs).catch(console.error);
   }, []);
 
   return (
     <Box className={styles.container}>
-      <Button as={Link} href="/onboarding" colorScheme="brand" mb={4}>
-        Complete Onboarding
-      </Button>
-      <SimpleGrid columns={{ base: 1, md: 3 }} spacing={6} mb={10}>
+      <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4} mb={4}>
+        <Button as={Link} href="/onboarding" colorScheme="brand">
+          Complete Onboarding
+        </Button>
+        <Button as={Link} href="/gigs" colorScheme="teal">
+          Browse Gigs
+        </Button>
+      </SimpleGrid>
+      <SimpleGrid columns={{ base: 1, md: 4 }} spacing={6} mb={10}>
         <DashboardCard title="Users">
           <Stat>
             <StatLabel>Total Users</StatLabel>
@@ -66,6 +77,12 @@ export default function DashboardPage() {
           <Stat>
             <StatLabel>Monthly</StatLabel>
             <StatNumber>$0</StatNumber>
+          </Stat>
+        </DashboardCard>
+        <DashboardCard title="Gigs">
+          <Stat>
+            <StatLabel>Total Gigs</StatLabel>
+            <StatNumber>{gigs.length}</StatNumber>
           </Stat>
         </DashboardCard>
       </SimpleGrid>

--- a/app/(dashboard)/gigs/page.module.css
+++ b/app/(dashboard)/gigs/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  width: 100%;
+}

--- a/app/(dashboard)/gigs/page.tsx
+++ b/app/(dashboard)/gigs/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Grid,
+  GridItem,
+  Input,
+  Select,
+  Stack,
+  Heading,
+  Button,
+} from "@chakra-ui/react";
+import api from "@/lib/api";
+import GigCard, { Gig } from "@/components/GigCard";
+import styles from "./page.module.css";
+
+interface GigResponse extends Gig {}
+
+export default function GigSearchPage() {
+  const [gigs, setGigs] = useState<GigResponse[]>([]);
+  const [recommended, setRecommended] = useState<GigResponse[]>([]);
+
+  const [query, setQuery] = useState("");
+  const [category, setCategory] = useState("");
+  const [minPrice, setMinPrice] = useState("" as string);
+  const [maxPrice, setMaxPrice] = useState("" as string);
+  const [deliveryTime, setDeliveryTime] = useState("");
+  const [rating, setRating] = useState("");
+  const [sort, setSort] = useState("Most Relevant");
+
+  const fetchData = () => {
+    const params = new URLSearchParams();
+    if (query) params.append("q", query);
+    if (category) params.append("category", category);
+    if (minPrice) params.append("minPrice", minPrice);
+    if (maxPrice) params.append("maxPrice", maxPrice);
+    if (deliveryTime) params.append("deliveryTime", deliveryTime);
+    if (rating) params.append("rating", rating);
+    if (sort) params.append("sort", sort);
+    api
+      .get<GigResponse[]>(`/gigs?${params.toString()}`)
+      .then(setGigs)
+      .catch(console.error);
+  };
+
+  useEffect(() => {
+    fetchData();
+    api
+      .get<GigResponse[]>("/gigs?sort=Highest%20Rated")
+      .then(setRecommended)
+      .catch(console.error);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <Box className={styles.container}>
+      <Heading mb={4}>Browse Gigs</Heading>
+      <Stack direction={{ base: "column", md: "row" }} spacing={4} mb={6}>
+        <Input
+          placeholder="Search gigs"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <Select
+          placeholder="Category"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+        >
+          <option value="Design">Design</option>
+          <option value="Programming">Programming</option>
+          <option value="Writing">Writing</option>
+        </Select>
+        <Input
+          placeholder="Min Price"
+          type="number"
+          value={minPrice}
+          onChange={(e) => setMinPrice(e.target.value)}
+        />
+        <Input
+          placeholder="Max Price"
+          type="number"
+          value={maxPrice}
+          onChange={(e) => setMaxPrice(e.target.value)}
+        />
+        <Select
+          placeholder="Delivery"
+          value={deliveryTime}
+          onChange={(e) => setDeliveryTime(e.target.value)}
+        >
+          <option value="1">24 Hours</option>
+          <option value="3">3 Days</option>
+          <option value="7">1 Week</option>
+        </Select>
+        <Select
+          placeholder="Rating"
+          value={rating}
+          onChange={(e) => setRating(e.target.value)}
+        >
+          <option value="3">3+ stars</option>
+          <option value="4">4+ stars</option>
+          <option value="4.5">4.5+ stars</option>
+        </Select>
+        <Select value={sort} onChange={(e) => setSort(e.target.value)}>
+          <option>Most Relevant</option>
+          <option>Highest Rated</option>
+          <option>Newest</option>
+        </Select>
+        <Button colorScheme="brand" onClick={fetchData}>
+          Apply
+        </Button>
+      </Stack>
+
+      <Grid templateColumns="repeat(auto-fill, minmax(250px, 1fr))" gap={6}>
+        {gigs.map((gig) => (
+          <GridItem key={gig.id}>
+            <GigCard gig={gig} />
+          </GridItem>
+        ))}
+      </Grid>
+
+      {recommended.length > 0 && (
+        <Box mt={10}>
+          <Heading size="md" mb={4}>
+            Recommended for You
+          </Heading>
+          <Grid templateColumns="repeat(auto-fill, minmax(250px, 1fr))" gap={6}>
+            {recommended.map((gig) => (
+              <GridItem key={`rec-${gig.id}`}>
+                <GigCard gig={gig} />
+              </GridItem>
+            ))}
+          </Grid>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/app/api/gigs/route.ts
+++ b/app/api/gigs/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { fetchGigs } from "@/lib/services/gigService";
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const filters = {
+    category: searchParams.get("category") || undefined,
+    minPrice: searchParams.get("minPrice") ? Number(searchParams.get("minPrice")) : undefined,
+    maxPrice: searchParams.get("maxPrice") ? Number(searchParams.get("maxPrice")) : undefined,
+    deliveryTime: searchParams.get("deliveryTime") ? Number(searchParams.get("deliveryTime")) : undefined,
+    rating: searchParams.get("rating") ? Number(searchParams.get("rating")) : undefined,
+    query: searchParams.get("q") || undefined,
+    sort: (searchParams.get("sort") as any) || undefined,
+  };
+
+  const gigs = await fetchGigs(filters);
+  return NextResponse.json(gigs);
+}

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -8,7 +8,7 @@ import {
 
 export async function GET() {
   const session = await getServerSession(authOptions);
-  const id = session?.user?.id ? Number(session.user.id) : undefined;
+  const id = session?.user ? Number((session.user as any).id) : undefined;
   if (!id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -18,7 +18,7 @@ export async function GET() {
 
 export async function PATCH(req: Request) {
   const session = await getServerSession(authOptions);
-  const id = session?.user?.id ? Number(session.user.id) : undefined;
+  const id = session?.user ? Number((session.user as any).id) : undefined;
   if (!id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/components/GigCard.module.css
+++ b/components/GigCard.module.css
@@ -1,0 +1,14 @@
+.card {
+  background: white;
+  transition: box-shadow 0.2s ease-in-out;
+}
+
+.card:hover {
+  box-shadow: var(--chakra-shadows-md);
+}
+
+.image {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+}

--- a/components/GigCard.tsx
+++ b/components/GigCard.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Box, Image, Text, Badge, Stack, Flex } from "@chakra-ui/react";
+import styles from "./GigCard.module.css";
+
+export interface Gig {
+  id: number;
+  title: string;
+  price: number;
+  rating: number;
+  category: string;
+  deliveryTime: number;
+  image?: string | null;
+  seller: { id: number; name: string | null };
+}
+
+export default function GigCard({ gig }: { gig: Gig }) {
+  return (
+    <Box borderWidth="1px" borderRadius="lg" overflow="hidden" className={styles.card}>
+      {gig.image && (
+        <Image src={gig.image} alt={gig.title} className={styles.image} />
+      )}
+      <Box p={4}>
+        <Stack spacing={2}>
+          <Text fontWeight="bold" fontSize="lg">
+            {gig.title}
+          </Text>
+          <Flex justify="space-between" align="center">
+            <Badge colorScheme="green">${gig.price}</Badge>
+            <Text fontSize="sm" color="gray.600">
+              {gig.rating.toFixed(1)} ★
+            </Text>
+          </Flex>
+          <Text fontSize="sm" color="gray.500">
+            {gig.seller.name}
+          </Text>
+          <Text fontSize="sm" color="gray.500">
+            {gig.deliveryTime} day{gig.deliveryTime !== 1 ? "s" : ""} delivery
+          </Text>
+        </Stack>
+      </Box>
+    </Box>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -10,6 +10,7 @@ export default function Sidebar() {
   const links = [
     { href: "/dashboard", label: "Dashboard" },
     { href: "/search", label: "Search" },
+    { href: "/gigs", label: "Browse Gigs" },
     { href: "/onboarding", label: "Onboarding" },
     { href: "/profile", label: "Profile" },
     { href: "/profile/edit", label: "Edit Profile" },

--- a/lib/services/gigService.ts
+++ b/lib/services/gigService.ts
@@ -1,0 +1,49 @@
+import prisma from "@/lib/prisma";
+
+export interface GigFilters {
+  category?: string;
+  minPrice?: number;
+  maxPrice?: number;
+  deliveryTime?: number;
+  rating?: number;
+  query?: string;
+  sort?: "Most Relevant" | "Highest Rated" | "Newest";
+}
+
+export async function fetchGigs(filters: GigFilters = {}) {
+  const { category, minPrice, maxPrice, deliveryTime, rating, query, sort } = filters;
+  const where: any = {};
+
+  if (category) where.category = category;
+  if (minPrice !== undefined || maxPrice !== undefined) {
+    where.price = {};
+    if (minPrice !== undefined) where.price.gte = minPrice;
+    if (maxPrice !== undefined) where.price.lte = maxPrice;
+  }
+  if (deliveryTime !== undefined) where.deliveryTime = { lte: deliveryTime };
+  if (rating !== undefined) where.rating = { gte: rating };
+  if (query) {
+    where.OR = [
+      { title: { contains: query, mode: "insensitive" } },
+      { description: { contains: query, mode: "insensitive" } },
+    ];
+  }
+
+  let orderBy: any;
+  switch (sort) {
+    case "Highest Rated":
+      orderBy = { rating: "desc" };
+      break;
+    case "Newest":
+      orderBy = { createdAt: "desc" };
+      break;
+    default:
+      orderBy = { id: "asc" };
+  }
+
+  return prisma.gig.findMany({
+    where,
+    orderBy,
+    include: { seller: { select: { id: true, name: true } } },
+  });
+}

--- a/prisma/migrations/20250207000003_add_gigs/migration.sql
+++ b/prisma/migrations/20250207000003_add_gigs/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "public"."Gig" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "price" DOUBLE PRECISION NOT NULL,
+    "category" TEXT NOT NULL,
+    "deliveryTime" INTEGER NOT NULL,
+    "rating" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "image" TEXT,
+    "sellerId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Gig_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "Gig_sellerId_fkey" FOREIGN KEY ("sellerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,7 @@ model User {
   coverLetter String?
   notifications Notification[]
   projects      Project[]
+  gigs          Gig[]
 }
 
 model Testimonial {
@@ -50,4 +51,18 @@ model Notification {
   message   String
   read      Boolean  @default(false)
   createdAt DateTime @default(now())
+}
+
+model Gig {
+  id           Int      @id @default(autoincrement())
+  title        String
+  description  String
+  price        Float
+  category     String
+  deliveryTime Int
+  rating       Float   @default(0)
+  image        String?
+  seller       User     @relation(fields: [sellerId], references: [id])
+  sellerId     Int
+  createdAt    DateTime @default(now())
 }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -56,6 +56,30 @@ async function main() {
       ],
       skipDuplicates: true,
     });
+
+    await prisma.gig.createMany({
+      data: [
+        {
+          title: 'Logo Design',
+          description: 'Professional logo design tailored to your brand identity.',
+          price: 150,
+          category: 'Design',
+          deliveryTime: 3,
+          rating: 4.8,
+          sellerId: admin.id,
+        },
+        {
+          title: 'Full-Stack Web App',
+          description: 'End-to-end development of modern web applications.',
+          price: 2000,
+          category: 'Programming',
+          deliveryTime: 14,
+          rating: 4.9,
+          sellerId: admin.id,
+        },
+      ],
+      skipDuplicates: true,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- add Prisma Gig model and seed data
- implement gig search API with filtering and sorting
- build Chakra UI gig browsing page and integrate with dashboard navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689542d291948320aa95df4198b8d24b