### PR TITLE
Add user id support in NextAuth session

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -34,4 +34,12 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   session: { strategy: "jwt" },
+  callbacks: {
+    session({ session, token }) {
+      if (session.user && token.sub) {
+        session.user.id = token.sub;
+      }
+      return session;
+    },
+  },
 };

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,0 +1,12 @@
+import { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+    } & DefaultSession["user"];
+  }
+  interface User {
+    id: string;
+  }
+}


### PR DESCRIPTION
## Summary
- Add NextAuth session callback to populate `user.id` from the JWT
- Declare NextAuth types so `session.user` exposes an `id` field

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Module not found: Can't resolve '@chakra-ui/icons')*


------
https://chatgpt.com/codex/tasks/task_e_68954d91e5c88320b1dd9abc8b6e66fd