### PR TITLE
Specify NextAuth secret via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The project expects a PostgreSQL connection string and NextAuth configuration:
 - `NEXTAUTH_SECRET` – long random string used to sign authentication tokens
 - `NEXTAUTH_URL` – public URL where the application is hosted (defaults to `http://localhost:3000` during development)
 
+For production deployments (e.g., Vercel), be sure to configure these variables in your hosting environment settings, especially `NEXTAUTH_SECRET`, to avoid runtime errors.
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -51,6 +51,7 @@ export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
   providers,
   session: { strategy: "jwt" },
+  secret: process.env.NEXTAUTH_SECRET,
   callbacks: {
     session({ session, token }) {
       if (session.user && token.sub) {


### PR DESCRIPTION
## Summary
- add explicit `NEXTAUTH_SECRET` usage in NextAuth config
- clarify production env setup in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68955cbd40508320a8ffc5b9bec28a62