### PR TITLE
Expand frontend roadmap to 60 stages

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,61 +1,64 @@
 # Development Roadmap
 
-This document consolidates high-level guidance from `frontend_guide.md` and `backend_guide.md`. Each stage references the relevant sections for detailed design instructions.
+This roadmap breaks `frontend_guide.md` into sixty sequential stages.
 
-## Frontend Stages
-
-1. **Project setup and dependency installation** – see `frontend_guide.md` introduction.
-2. **Pre-login landing page** – see `frontend_guide.md` section 1.1 for layout and objectives.
-3. **User registration flow** – see registration guidelines in `frontend_guide.md` section 1.
-4. **Login and session management** – see `frontend_guide.md` section 1 on authentication screens.
-5. **Post-login dashboard shell** – reference dashboard setup in `frontend_guide.md` early sections.
-6. **Profile onboarding wizard** – see profile setup directions in `frontend_guide.md`.
-7. **Profile editing interface** – see `frontend_guide.md` guidance on profile forms.
-8. **Notification center UI** – consult notification layout notes in `frontend_guide.md`.
-9. **Search interface with filters** – see search design notes in `frontend_guide.md`.
-10. **Job posting form** – reference job post form details in `frontend_guide.md`.
-11. **Gig browsing page** – see gig marketplace layout in `frontend_guide.md`.
-12. **Freelance gig management UI** – see task management sections in `frontend_guide.md`.
-13. **Messaging interface** – consult chat and communication guidelines in `frontend_guide.md`.
-14. **Billing & subscription page** – see combined billing section 18.2 in `frontend_guide.md`.
-15. **Payment method form** – see payment method form specification in `frontend_guide.md`.
-16. **Stats and analytics dashboard** – see section 18.3 in `frontend_guide.md`.
-17. **User settings page** – reference settings layout in `frontend_guide.md`.
-18. **Admin UI shell** – see administrative interface sections in `frontend_guide.md`.
-19. **Support & dispute form** – see support page form details in `frontend_guide.md`.
-20. **User/content management admin page** – consult admin content management notes in `frontend_guide.md`.
-21. **System settings page** – see system settings design in `frontend_guide.md`.
-22. **Affiliate management interface** – see affiliate management section 21.6 in `frontend_guide.md`.
-23. **Responsive design pass** – cross-check responsive guidelines in `frontend_guide.md`.
-24. **Accessibility review** – follow accessibility guidance in `frontend_guide.md`.
-25. **Deploy frontend to Vercel** – reference deployment considerations in `frontend_guide.md`.
-
-## Backend Stages
-
-26. **Initialize database schema with Prisma** – see schema setup notes in `backend_guide.md`.
-27. **Authentication endpoints** – reference auth sections in `backend_guide.md`.
-28. **User profile API** – see profile endpoint specifications in `backend_guide.md`.
-29. **Notification service endpoints** – consult notification API notes in `backend_guide.md`.
-30. **Search API endpoints** – see search service sections in `backend_guide.md`.
-31. **Job posting endpoints** – reference job controller design in `backend_guide.md`.
-32. **Gig management endpoints** – consult gig controller section in `backend_guide.md`.
-33. **Messaging backend** – see messaging endpoints in `backend_guide.md`.
-34. **Billing & subscription endpoints** – reference billing API design in `backend_guide.md`.
-35. **Payment method management** – see payment endpoints in `backend_guide.md`.
-36. **Stats & analytics aggregation** – consult analytics sections in `backend_guide.md`.
-37. **Settings endpoints** – see settings controller in `backend_guide.md`.
-38. **Admin dashboard endpoints** – reference admin APIs in `backend_guide.md`.
-39. **Support & dispute resolution endpoints** – see support controller specs in `backend_guide.md`.
-40. **Content moderation endpoints** – consult moderation sections in `backend_guide.md`.
-41. **System settings & employee management** – see system management notes in `backend_guide.md`.
-42. **Affiliate program management** – see `backend_guide.md` lines 13-17 for affiliate controller.
-43. **Commission calculation service** – see `backend_guide.md` lines 21-28 for commission controller.
-44. **Payout processing endpoints** – see `backend_guide.md` lines 29-32 for payout controller.
-45. **Referral tracking endpoints** – see `backend_guide.md` lines 33-35 for referral controller.
-46. **Marketing link generation** – see `backend_guide.md` lines 36-38 for link controller.
-47. **Onboarding resources API** – see `backend_guide.md` lines 39-40 for onboarding controller.
-48. **Logging & monitoring setup** – reference logging guidance in `backend_guide.md`.
-49. **Testing & quality assurance** – see testing notes in `backend_guide.md`.
-50. **Deployment & CI/CD integration** – finalize using deployment instructions in `backend_guide.md`.
-
-For more detailed design references, consult the respective sections in `frontend_guide.md` and `backend_guide.md` as noted above.
+1. **Homepage Before Login** – see `frontend_guide.md` section 1.1.
+2. **Combined Sign-Up and User Information Page** – see section 1.2.1.
+3. **Financials & Media Setup Page** – see section 1.2.2.
+4. **Combined CV & Cover Letter Upload/Creation Page** – see section 1.2.3.
+5. **Login Page** – see section 1.2.4.
+6. **Combined Homepage After Login & Main Home Page** – see section 2.1.
+7. **Live Feed Section** – see section 2.2.
+8. **Main Profile Page** – see section 3.1.
+9. **Profile Customization Page** – see section 3.2.
+10. **Combined Pop-Up Chat and Full Inbox Page** – see section 4.1.
+11. **Employment Dashboard (Job-Seeker and Company-Side)** – see section 5.1.
+12. **Combined Job Listings and Details Page** – see section 5.2.
+13. **Combined Application and Interview Management Page** – see section 5.3.
+14. **Headhunter Dashboard** – see section 5.4.
+15. **Virtual Interview Page** – see section 5.5.
+16. **Job Post Creation and Management Page** – see section 5.6.
+17. **Combined Gigs Dashboard (Gig Seller and Buyer)** – see section 6.1.
+18. **Combined Order Management Page (Gig Seller and Buyer)** – see section 6.2.
+19. **Gig Creation and Management Page** – see section 6.3.
+20. **Product Page (Buyer View)** – see section 6.4.
+21. **Payment Page** – see section 6.5.
+22. **Gig Search and Discovery Page** – see section 6.6.
+23. **Combined Dashboard (Client and Freelancer)** – see section 7.1.
+24. **Contract Management Page (Client and Freelancer)** – see section 7.2.
+25. **Freelancer Search** – see section 7.3.
+26. **Proposal and Invoice Management Page** – see section 7.4.
+27. **Payment and Timesheet Management Page** – see section 7.5.
+28. **Contract Creation and Editing Page** – see section 7.6.
+29. **Combined Education Dashboard (Student and Teacher)** – see section 8.1.
+30. **Combined Classroom Page** and **Combined Course and Module Management Page** – see sections 8.2 and 8.3.
+31. **Schedule and Calendar Page** and **Course Purchase and Details Page** – see sections 8.4 and 8.5.
+32. **(Local) Services Section Overview** and **Combined Service and Order Management Page** – see sections 9 and 9.2.
+33. **Service Creation and Editing Page** and **Search and Service Details Page** – see sections 9.3 and 9.4.
+34. **Calendar Page (Seller and Buyer)** and **Combined Task Dashboard (Creator and Tasker)** – see sections 9.5 and 10.1.
+35. **Task Creation and Management Page (Creator)** and **Task Search and Details Page (Tasker)** – see sections 10.2 and 10.3.
+36. **Task and Schedule Management Page (Tasker)** and **Combined Experience Dashboard** – see sections 10.4 and 11.1.
+37. **Combined Opportunity Management Page** and **Opportunity Search and Details Page** – see sections 11.2 and 11.3.
+38. **Participant and Provider Progress Page** and **Combined Volunteering Dashboard** – see sections 11.4 and 12.1.
+39. **Combined Opportunity Search and Details Page (Volunteers)** and **Combined Application and Volunteer Tracking Page** – see sections 12.2 and 12.3.
+40. **Opportunity Management Page (Employers)** and **Combined Networking Dashboard** – see sections 12.4 and 13.1.
+41. **Combined Session Listings and Details Page** and **In-Session Networking Page** – see sections 13.2 and 13.3.
+42. **Session Management Page (Companies)** and **Profile and Connection Management Page (Shared)** – see sections 13.4 and 13.5.
+43. **Combined Creator Dashboard (Podcasts and Webinars)** and **Combined Content Creation and Management Page** – see sections 14.1 and 14.2.
+44. **Combined Content Library and Details Page** and **Live/Playback Room Page** – see sections 14.3 and 14.4.
+45. **Profile and Analytics Page (Creators/Hosts)** and **Combined Ads Dashboard and Campaign Management Page** – see sections 14.5 and 15.1.
+46. **Ad Creation and Editing Page** and **Combined Billing, Analytics, and Ad Library Page** – see sections 15.2 and 15.3.
+47. **Shared User Interaction Page** and **Combined Dashboard (Startups, Investors, Mentors)** – see sections 15.4 and 16.1.
+48. **Profile and Plan Management Page (Startups)** and **Search and Connection Page** – see sections 16.2 and 16.3.
+49. **Connection and Relationship Management Page** and **Live Engagement and Analytics Page** – see sections 16.4 and 16.5.
+50. **Combined Workspace Dashboard** and **Project Creation and Management Page** – see sections 17.1 and 17.2.
+51. **Unified Schedule and Calendar Page** and **Task and Workflow Management Page** – see sections 17.3 and 17.4.
+52. **File and Resource Management Page** and **Combined Settings Page** – see sections 17.5 and 18.1.
+53. **Message Notifications and Settings Page – Design Brief** and **Combined Billing and Subscription Page** – see sections 18.2 and 18.2.
+54. **Combined Stats and Analytics Page** and **Combined Blog Homepage and Categories Page** – see sections 18.3 and 19.1.
+55. **Article Page** and **Combined Contributor Dashboard and Post Management Page** – see sections 19.2 and 19.3.
+56. **Combined Post Creation and Editing Page** and **Combined Dispute Dashboard (Disputor and Disputee)** – see sections 19.4 and 20.1.
+57. **Dispute Management Page (Details and Resolution Tools)** and **Dispute Creation and Response Form Page** – see sections 20.2 and 20.3.
+58. **Role-Based Combined Admin Dashboard** and **Unified Support and Dispute Management Page** – see sections 21.1 and 21.2.
+59. **User and Content Management Page with Role-Specific Access** and **Combined Analytics and Audit Page** – see sections 21.3 and 21.4.
+60. **System Settings and Employee Management Page** and **Affiliate Management** – see sections 21.5 and 21.6.


### PR DESCRIPTION
## Summary
- Replace existing roadmap with 60 detailed stages covering every frontend page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68956359e5888320a2bfe083d9572086