### PR TITLE
Revamp landing page with enterprise sections and links

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Container, Heading, Text } from "@chakra-ui/react";
+
+export default function AboutPage() {
+  return (
+    <Container maxW="4xl" py={20}>
+      <Heading mb={4}>About Orbas</Heading>
+      <Text mb={2}>
+        Orbas is dedicated to empowering professionals and organizations with tools that simplify
+        collaboration and unlock opportunity.
+      </Text>
+      <Text>
+        Our platform blends advanced matching, workflow automation, and insightful analytics to help
+        teams hire, manage gigs, and grow with confidence.
+      </Text>
+    </Container>
+  );
+}

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -6,3 +6,68 @@
   background-color: rgba(255, 255, 255, 0.95);
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
+
+.hero {
+  position: relative;
+  height: 500px;
+  overflow: hidden;
+}
+
+.heroImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: brightness(0.6);
+}
+
+.heroOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  background: linear-gradient(135deg, rgba(34,43,85,0.8), rgba(94,114,228,0.8));
+  text-align: center;
+  padding: 1rem;
+}
+
+.featureCard {
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.featureImage {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+.solutionCard {
+  transition: transform 0.2s ease;
+}
+
+.solutionCard:hover {
+  transform: translateY(-4px);
+}
+
+.solutionImage {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+.pricingCard {
+  transition: transform 0.2s ease;
+}
+
+.pricingCard:hover {
+  transform: translateY(-4px);
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,18 +9,22 @@ import {
   Text,
   Stack,
   SimpleGrid,
-  Icon,
   Image,
   Link,
   Container,
 } from "@chakra-ui/react";
 import NextLink from "next/link";
-import { FaBrain, FaTasks, FaChartLine } from "react-icons/fa";
 import TestimonialCarousel from "@/components/TestimonialCarousel";
 import styles from "./page.module.css";
 
 export default function LandingPage() {
   const [isScrolled, setIsScrolled] = useState(false);
+  const heroImages = [
+    "https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1462331940025-496dfbfc7564.jpg",
+    "https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1495431088732-09e59535d241.jpg",
+    "https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1503435980610-a51f3ddfee50.jpg",
+  ];
+  const [heroIndex, setHeroIndex] = useState(0);
 
   useEffect(() => {
     const handler = () => setIsScrolled(window.scrollY > 10);
@@ -28,6 +32,14 @@ export default function LandingPage() {
     window.addEventListener("scroll", handler);
     return () => window.removeEventListener("scroll", handler);
   }, []);
+
+  useEffect(() => {
+    const id = setInterval(
+      () => setHeroIndex((i) => (i + 1) % heroImages.length),
+      5000
+    );
+    return () => clearInterval(id);
+  }, [heroImages.length]);
 
   return (
     <Box>
@@ -45,7 +57,8 @@ export default function LandingPage() {
         <Heading size="md">Orbas</Heading>
         <Stack direction="row" spacing={6} align="center">
           <Link as={NextLink} href="#features">Features</Link>
-          <Link as={NextLink} href="#about">About</Link>
+          <Link as={NextLink} href="#solutions">Solutions</Link>
+          <Link as={NextLink} href="/about">About</Link>
           <Button as={NextLink} href="/login" variant="ghost">
             Login
           </Button>
@@ -55,50 +68,143 @@ export default function LandingPage() {
         </Stack>
       </Flex>
 
-      <Box textAlign="center" py={24} px={4} bg="gray.50">
-        <Container maxW="4xl">
-          <Heading size="2xl" mb={4}>
-            Empowering Talent with AI and Insight
-          </Heading>
-          <Text fontSize="lg" mb={8}>
-            Streamline recruiting, manage gigs, and track performance with one integrated platform.
-          </Text>
-          <Button colorScheme="brand" size="lg" as={NextLink} href="/signup">
-            Get Started
-          </Button>
-        </Container>
+      <Box className={styles.hero}>
+        <Image
+          src={heroImages[heroIndex]}
+          alt="Inspiring workplace"
+          className={styles.heroImage}
+        />
+        <Box className={styles.heroOverlay}>
+          <Container maxW="4xl" textAlign="center">
+            <Heading size="2xl" mb={4}>
+              Empowering Talent with AI and Insight
+            </Heading>
+            <Text fontSize="lg" mb={8}>
+              Streamline recruiting, manage gigs, and track performance with one integrated platform.
+            </Text>
+            <Button colorScheme="brand" size="lg" as={NextLink} href="/signup">
+              Get Started
+            </Button>
+          </Container>
+        </Box>
       </Box>
 
       <Box py={20} px={4} id="features">
         <Container maxW="6xl">
+          <Heading size="lg" textAlign="center" mb={10}>
+            Platform Highlights
+          </Heading>
           <SimpleGrid columns={{ base: 1, md: 3 }} spacing={8}>
-            <Stack align="center" spacing={3}>
-              <Icon as={FaBrain} boxSize={8} color="brand.500" />
+            <Stack align="center" spacing={3} className={styles.featureCard}>
+              <Image
+                src="https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1456244440184-1d494704a505.jpg"
+                alt="AI matching"
+                className={styles.featureImage}
+              />
               <Heading size="md">AI-Powered Matching</Heading>
-              <Text textAlign="center">Connect with the right opportunities using intelligent algorithms.</Text>
+              <Text textAlign="center">
+                Connect with the right opportunities using intelligent algorithms.
+              </Text>
             </Stack>
-            <Stack align="center" spacing={3}>
-              <Icon as={FaTasks} boxSize={8} color="brand.500" />
+            <Stack align="center" spacing={3} className={styles.featureCard}>
+              <Image
+                src="https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1500393734221-584dd6dbf92a.jpg"
+                alt="Gig management"
+                className={styles.featureImage}
+              />
               <Heading size="md">Integrated Gig Management</Heading>
-              <Text textAlign="center">Manage tasks and projects seamlessly in one place.</Text>
+              <Text textAlign="center">
+                Manage tasks and projects seamlessly in one place.
+              </Text>
             </Stack>
-            <Stack align="center" spacing={3}>
-              <Icon as={FaChartLine} boxSize={8} color="brand.500" />
+            <Stack align="center" spacing={3} className={styles.featureCard}>
+              <Image
+                src="https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1462332420958-a05d1e002413.jpg"
+                alt="Analytics dashboard"
+                className={styles.featureImage}
+              />
               <Heading size="md">Real-Time Analytics</Heading>
-              <Text textAlign="center">Gain insights with up-to-the-minute data and reports.</Text>
+              <Text textAlign="center">
+                Gain insights with up-to-the-minute data and reports.
+              </Text>
             </Stack>
           </SimpleGrid>
         </Container>
       </Box>
 
-      <Box py={20} px={4} bg="white" id="about">
-        <Container maxW="4xl" textAlign="center">
-          <Heading size="lg" mb={4}>About Us</Heading>
-          <Text mb={6}>
-            Orbas brings job seekers, freelancers, and employers together. Our mission is to simplify talent discovery
-            and collaboration through intuitive tools and smart automation.
-          </Text>
-          <Image src="/globe.svg" alt="About Orbas" mx="auto" boxSize={{ base: "150px", md: "200px" }} />
+      <Box py={20} px={4} bg="gray.50" id="solutions">
+        <Container maxW="6xl">
+          <Heading size="lg" textAlign="center" mb={10}>
+            Enterprise Solutions
+          </Heading>
+          <SimpleGrid columns={{ base: 1, md: 3 }} spacing={8}>
+            <Stack
+              spacing={4}
+              p={6}
+              bg="white"
+              borderRadius="md"
+              boxShadow="md"
+              align="center"
+              className={styles.solutionCard}
+            >
+              <Image
+                src="https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1489343511429-5482f78c15cf.jpg"
+                alt="Recruiting suite"
+                className={styles.solutionImage}
+              />
+              <Heading size="md">Recruiting Suite</Heading>
+              <Text textAlign="center">
+                Automate sourcing and streamline applicant tracking with one unified hub.
+              </Text>
+              <Button colorScheme="brand" variant="outline">
+                Learn More
+              </Button>
+            </Stack>
+            <Stack
+              spacing={4}
+              p={6}
+              bg="white"
+              borderRadius="md"
+              boxShadow="md"
+              align="center"
+              className={styles.solutionCard}
+            >
+              <Image
+                src="https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1494253188410-ff0cdea5499e.jpg"
+                alt="Gig marketplace"
+                className={styles.solutionImage}
+              />
+              <Heading size="md">Gig Marketplace</Heading>
+              <Text textAlign="center">
+                Connect freelancers and employers with secure contracts and messaging.
+              </Text>
+              <Button colorScheme="brand" variant="outline">
+                Explore
+              </Button>
+            </Stack>
+            <Stack
+              spacing={4}
+              p={6}
+              bg="white"
+              borderRadius="md"
+              boxShadow="md"
+              align="center"
+              className={styles.solutionCard}
+            >
+              <Image
+                src="https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1504888302758-9adb6780e7c8.jpg"
+                alt="Analytics portal"
+                className={styles.solutionImage}
+              />
+              <Heading size="md">Analytics Portal</Heading>
+              <Text textAlign="center">
+                Visualize performance trends and make data-driven decisions instantly.
+              </Text>
+              <Button colorScheme="brand" variant="outline">
+                View Dashboard
+              </Button>
+            </Stack>
+          </SimpleGrid>
         </Container>
       </Box>
 
@@ -112,6 +218,73 @@ export default function LandingPage() {
             <Image src="/next.svg" alt="Partner" boxSize="60px" opacity={0.6} />
             <Image src="/vercel.svg" alt="Partner" boxSize="60px" opacity={0.6} />
           </Stack>
+        </Container>
+      </Box>
+
+      <Box py={20} px={4} id="pricing">
+        <Container maxW="6xl">
+          <Heading size="lg" textAlign="center" mb={10}>
+            Flexible Pricing
+          </Heading>
+          <SimpleGrid columns={{ base: 1, md: 3 }} spacing={8}>
+            <Stack
+              spacing={4}
+              p={6}
+              bg="white"
+              borderRadius="md"
+              boxShadow="lg"
+              align="center"
+              className={styles.pricingCard}
+            >
+              <Heading size="md">Starter</Heading>
+              <Text fontSize="2xl" fontWeight="bold">Free</Text>
+              <Stack spacing={1}>
+                <Text>Basic job matching</Text>
+                <Text>Community support</Text>
+              </Stack>
+              <Button colorScheme="brand" variant="outline">
+                Get Starter
+              </Button>
+            </Stack>
+            <Stack
+              spacing={4}
+              p={6}
+              bg="white"
+              borderRadius="md"
+              boxShadow="lg"
+              align="center"
+              className={styles.pricingCard}
+            >
+              <Heading size="md">Pro</Heading>
+              <Text fontSize="2xl" fontWeight="bold">$29/mo</Text>
+              <Stack spacing={1}>
+                <Text>Advanced analytics</Text>
+                <Text>Priority support</Text>
+              </Stack>
+              <Button colorScheme="brand" variant="outline">
+                Choose Pro
+              </Button>
+            </Stack>
+            <Stack
+              spacing={4}
+              p={6}
+              bg="white"
+              borderRadius="md"
+              boxShadow="lg"
+              align="center"
+              className={styles.pricingCard}
+            >
+              <Heading size="md">Enterprise</Heading>
+              <Text fontSize="2xl" fontWeight="bold">Contact Us</Text>
+              <Stack spacing={1}>
+                <Text>Custom integrations</Text>
+                <Text>Dedicated manager</Text>
+              </Stack>
+              <Button colorScheme="brand" variant="outline">
+                Talk to Sales
+              </Button>
+            </Stack>
+          </SimpleGrid>
         </Container>
       </Box>
 
@@ -134,16 +307,19 @@ export default function LandingPage() {
             <Link as={NextLink} href="#features">
               Features
             </Link>
-            <Link as={NextLink} href="#about">
+            <Link as={NextLink} href="#solutions">
+              Solutions
+            </Link>
+            <Link as={NextLink} href="/about">
               About
             </Link>
-            <Link as={NextLink} href="#">
-              Contact
+            <Link as={NextLink} href="#pricing">
+              Pricing
             </Link>
-            <Link as={NextLink} href="#">
+            <Link as={NextLink} href="/privacy">
               Privacy
             </Link>
-            <Link as={NextLink} href="#">
+            <Link as={NextLink} href="/terms">
               Terms
             </Link>
           </Stack>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { Container, Heading, Text } from "@chakra-ui/react";
+
+export default function PrivacyPage() {
+  return (
+    <Container maxW="4xl" py={20}>
+      <Heading mb={4}>Privacy Policy</Heading>
+      <Text>
+        We are committed to protecting your personal information and ensuring transparency about how
+        your data is used within the Orbas platform.
+      </Text>
+    </Container>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { Container, Heading, Text } from "@chakra-ui/react";
+
+export default function TermsPage() {
+  return (
+    <Container maxW="4xl" py={20}>
+      <Heading mb={4}>Terms and Conditions</Heading>
+      <Text>
+        By accessing or using Orbas, you agree to our terms and conditions. Please review them
+        carefully to understand your rights and obligations when using our services.
+      </Text>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- Implement hero slideshow, new feature, solution, testimonial, pricing sections and updated navigation on landing page
- Add dedicated About, Privacy, and Terms pages linked from header and footer
- Apply modern styling with new gradients and hover effects

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68956ead19108320b3bd93f9de1a950c