### PR TITLE
feat: add live feed section

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -51,6 +51,9 @@ export default function DashboardPage() {
         <Button as={Link} href="/onboarding" colorScheme="brand">
           Complete Onboarding
         </Button>
+        <Button as={Link} href="/feed" colorScheme="brand" variant="outline">
+          Live Feed
+        </Button>
         <Button as={Link} href="/gigs" colorScheme="brand" variant="outline">
           Browse Gigs
         </Button>

--- a/app/(dashboard)/feed/page.module.css
+++ b/app/(dashboard)/feed/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  align-items: flex-start;
+}

--- a/app/(dashboard)/feed/page.tsx
+++ b/app/(dashboard)/feed/page.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Flex,
+  VStack,
+  Heading,
+  Textarea,
+  Button,
+  Select,
+} from "@chakra-ui/react";
+import FeedPost from "@/components/FeedPost";
+import LiveEvents from "@/components/LiveEvents";
+import {
+  LiveFeedPost,
+  getPosts,
+  createPost,
+} from "@/lib/services/liveFeedService";
+import styles from "./page.module.css";
+
+const categories = [
+  { value: "employment", label: "Employment" },
+  { value: "freelancing", label: "Freelancing" },
+  { value: "education", label: "Education" },
+  { value: "networking", label: "Networking" },
+  { value: "services", label: "Local Services" },
+];
+
+export default function LiveFeedPage() {
+  const [posts, setPosts] = useState<LiveFeedPost[]>([]);
+  const [content, setContent] = useState("");
+  const [category, setCategory] = useState(categories[0].value);
+  const [filter, setFilter] = useState<string | undefined>();
+
+  useEffect(() => {
+    getPosts(filter).then(setPosts).catch(() => setPosts([]));
+  }, [filter]);
+
+  const submitPost = async () => {
+    if (!content.trim()) return;
+    const newPost = await createPost(content, category);
+    setPosts((p) => [newPost, ...p]);
+    setContent("");
+  };
+
+  return (
+    <Flex className={styles.container} gap={4}>
+      <Box flex="1">
+        <Box mb={4} p={4} bg="white" borderWidth="1px" borderRadius="md">
+          <Heading size="md" mb={2}>
+            Create Post
+          </Heading>
+          <Select
+            mb={2}
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+          >
+            {categories.map((c) => (
+              <option key={c.value} value={c.value}>
+                {c.label}
+              </option>
+            ))}
+          </Select>
+          <Textarea
+            placeholder="Share something..."
+            mb={2}
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+          />
+          <Button colorScheme="brand" onClick={submitPost}>
+            Post
+          </Button>
+        </Box>
+
+        <Select
+          mb={4}
+          placeholder="Filter by category"
+          value={filter || ""}
+          onChange={(e) => setFilter(e.target.value || undefined)}
+        >
+          {categories.map((c) => (
+            <option key={c.value} value={c.value}>
+              {c.label}
+            </option>
+          ))}
+        </Select>
+
+        <VStack align="stretch">
+          {posts.map((post) => (
+            <FeedPost key={post.id} post={post} />
+          ))}
+        </VStack>
+      </Box>
+      <Box w={{ base: "100%", md: "sm" }}>
+        <LiveEvents />
+      </Box>
+    </Flex>
+  );
+}

--- a/components/FeedPost.module.css
+++ b/components/FeedPost.module.css
@@ -1,0 +1,3 @@
+.post {
+  margin-bottom: 1rem;
+}

--- a/components/FeedPost.tsx
+++ b/components/FeedPost.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useState } from "react";
+import { Box, Text, HStack, IconButton, useToast } from "@chakra-ui/react";
+import { FaHeart } from "react-icons/fa";
+import { LiveFeedPost, likePost } from "@/lib/services/liveFeedService";
+import styles from "./FeedPost.module.css";
+
+interface Props {
+  post: LiveFeedPost;
+}
+
+export default function FeedPost({ post }: Props) {
+  const [likes, setLikes] = useState(post.likes);
+  const toast = useToast();
+
+  const handleLike = async () => {
+    try {
+      await likePost(post.id);
+      setLikes((l) => l + 1);
+    } catch (e) {
+      toast({ status: "error", description: "Failed to like post" });
+    }
+  };
+
+  return (
+    <Box className={styles.post} borderWidth="1px" borderRadius="md" p={4} bg="white">
+      <Text fontWeight="bold" mb={2}>
+        {post.author}
+      </Text>
+      <Text mb={2}>{post.content}</Text>
+      <HStack spacing={2}>
+        <IconButton
+          aria-label="Like post"
+          icon={<FaHeart />}
+          onClick={handleLike}
+          size="sm"
+          colorScheme="pink"
+          variant="ghost"
+        />
+        <Text>{likes}</Text>
+      </HStack>
+    </Box>
+  );
+}

--- a/components/LiveEvents.module.css
+++ b/components/LiveEvents.module.css
@@ -1,0 +1,4 @@
+.container {
+  max-height: 80vh;
+  overflow-y: auto;
+}

--- a/components/LiveEvents.tsx
+++ b/components/LiveEvents.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, Heading, VStack, Text } from "@chakra-ui/react";
+import { LiveEvent, getLiveEvents } from "@/lib/services/liveFeedService";
+import styles from "./LiveEvents.module.css";
+
+export default function LiveEvents() {
+  const [events, setEvents] = useState<LiveEvent[]>([]);
+
+  useEffect(() => {
+    getLiveEvents().then(setEvents).catch(() => setEvents([]));
+  }, []);
+
+  return (
+    <Box className={styles.container} bg="white" p={4} borderWidth="1px" borderRadius="md">
+      <Heading size="md" mb={2}>
+        Live Now
+      </Heading>
+      <VStack align="stretch" spacing={2}>
+        {events.map((event) => (
+          <Box key={event.id} p={2} borderWidth="1px" borderRadius="md">
+            <Text fontWeight="bold">{event.title}</Text>
+            <Text fontSize="sm" color="gray.500">
+              {event.status}
+            </Text>
+          </Box>
+        ))}
+        {events.length === 0 && (
+          <Text fontSize="sm" color="gray.500">
+            No live events
+          </Text>
+        )}
+      </VStack>
+    </Box>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -9,6 +9,7 @@ export default function Sidebar() {
   const pathname = usePathname();
   const links = [
     { href: "/dashboard", label: "Dashboard" },
+    { href: "/feed", label: "Live Feed" },
     { href: "/search", label: "Search" },
     { href: "/onboarding", label: "Onboarding" },
     { href: "/profile", label: "Profile" },

--- a/lib/services/liveFeedService.ts
+++ b/lib/services/liveFeedService.ts
@@ -1,0 +1,35 @@
+import api from "../api";
+
+export interface LiveFeedPost {
+  id: string;
+  author: string;
+  content: string;
+  likes: number;
+  category: string;
+  createdAt: string;
+}
+
+export interface LiveEvent {
+  id: string;
+  title: string;
+  status: string;
+  startsAt: string;
+}
+
+export async function getPosts(category?: string): Promise<LiveFeedPost[]> {
+  const query = category ? `?category=${encodeURIComponent(category)}` : "";
+  return api.get<LiveFeedPost[]>(`/live-feed/posts${query}`);
+}
+
+export async function createPost(content: string, category: string): Promise<LiveFeedPost> {
+  return api.post<LiveFeedPost>("/live-feed/posts", { content, category });
+}
+
+export async function likePost(postId: string): Promise<void> {
+  await api.post(`/live-feed/posts/${postId}/likes`, {});
+}
+
+export async function getLiveEvents(): Promise<LiveEvent[]> {
+  return api.get<LiveEvent[]>("/live-feed/updates");
+}
+


### PR DESCRIPTION
## Summary
- add Live Feed navigation entry and dashboard shortcut
- implement Live Feed page with post creation, filtering, and live events sidebar
- create API service and reusable components for feed posts and live events

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689587f8d9208320a0f34666f69bb96d