### PR TITLE
feat: load landing content from backend

### DIFF
--- a/app/api/features/route.ts
+++ b/app/api/features/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+export async function GET() {
+  const features = await prisma.feature.findMany({
+    orderBy: { id: "asc" },
+  });
+  return NextResponse.json(features);
+}

--- a/app/api/solutions/route.ts
+++ b/app/api/solutions/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+export async function GET() {
+  const solutions = await prisma.solution.findMany({
+    orderBy: { id: "asc" },
+  });
+  return NextResponse.json(solutions);
+}

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -35,34 +35,6 @@
   padding: 1rem;
 }
 
-.featureCard {
-  background: white;
-  padding: 20px;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-}
-
-.featureImage {
-  width: 100%;
-  height: 180px;
-  object-fit: cover;
-  border-radius: 8px;
-}
-
-.solutionCard {
-  transition: transform 0.2s ease;
-}
-
-.solutionCard:hover {
-  transform: translateY(-4px);
-}
-
-.solutionImage {
-  width: 100%;
-  height: 160px;
-  object-fit: cover;
-  border-radius: 8px;
-}
 
 .pricingCard {
   transition: transform 0.2s ease;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,9 +12,13 @@ import {
   Image,
   Link,
   Container,
+  Spinner,
 } from "@chakra-ui/react";
 import NextLink from "next/link";
 import TestimonialCarousel from "@/components/TestimonialCarousel";
+import FeatureCard from "@/components/FeatureCard";
+import SolutionCard from "@/components/SolutionCard";
+import { fetchJson } from "@/lib/fetcher";
 import styles from "./page.module.css";
 
 export default function LandingPage() {
@@ -25,6 +29,22 @@ export default function LandingPage() {
     "https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1503435980610-a51f3ddfee50.jpg",
   ];
   const [heroIndex, setHeroIndex] = useState(0);
+  interface Feature {
+    id: number;
+    title: string;
+    description: string;
+    imageUrl: string;
+  }
+  interface Solution {
+    id: number;
+    title: string;
+    description: string;
+    imageUrl: string;
+    ctaText?: string | null;
+  }
+  const [features, setFeatures] = useState<Feature[]>([]);
+  const [solutions, setSolutions] = useState<Solution[]>([]);
+  const [loadingContent, setLoadingContent] = useState(true);
 
   useEffect(() => {
     const handler = () => setIsScrolled(window.scrollY > 10);
@@ -40,6 +60,24 @@ export default function LandingPage() {
     );
     return () => clearInterval(id);
   }, [heroImages.length]);
+
+  useEffect(() => {
+    async function loadContent() {
+      try {
+        const [featData, solData] = await Promise.all([
+          fetchJson<Feature[]>("/api/features"),
+          fetchJson<Solution[]>("/api/solutions"),
+        ]);
+        setFeatures(featData);
+        setSolutions(solData);
+      } catch (err) {
+        console.error("Failed to load landing content", err);
+      } finally {
+        setLoadingContent(false);
+      }
+    }
+    loadContent();
+  }, []);
 
   return (
     <Box>
@@ -94,41 +132,22 @@ export default function LandingPage() {
           <Heading size="lg" textAlign="center" mb={10}>
             Platform Highlights
           </Heading>
-          <SimpleGrid columns={{ base: 1, md: 3 }} spacing={8}>
-            <Stack align="center" spacing={3} className={styles.featureCard}>
-              <Image
-                src="https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1456244440184-1d494704a505.jpg"
-                alt="AI matching"
-                className={styles.featureImage}
-              />
-              <Heading size="md">AI-Powered Matching</Heading>
-              <Text textAlign="center">
-                Connect with the right opportunities using intelligent algorithms.
-              </Text>
-            </Stack>
-            <Stack align="center" spacing={3} className={styles.featureCard}>
-              <Image
-                src="https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1500393734221-584dd6dbf92a.jpg"
-                alt="Gig management"
-                className={styles.featureImage}
-              />
-              <Heading size="md">Integrated Gig Management</Heading>
-              <Text textAlign="center">
-                Manage tasks and projects seamlessly in one place.
-              </Text>
-            </Stack>
-            <Stack align="center" spacing={3} className={styles.featureCard}>
-              <Image
-                src="https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1462332420958-a05d1e002413.jpg"
-                alt="Analytics dashboard"
-                className={styles.featureImage}
-              />
-              <Heading size="md">Real-Time Analytics</Heading>
-              <Text textAlign="center">
-                Gain insights with up-to-the-minute data and reports.
-              </Text>
-            </Stack>
-          </SimpleGrid>
+          {loadingContent ? (
+            <Flex justify="center" py={10}>
+              <Spinner />
+            </Flex>
+          ) : (
+            <SimpleGrid columns={{ base: 1, md: 3 }} spacing={8}>
+              {features.map((f) => (
+                <FeatureCard
+                  key={f.id}
+                  title={f.title}
+                  description={f.description}
+                  imageUrl={f.imageUrl}
+                />
+              ))}
+            </SimpleGrid>
+          )}
         </Container>
       </Box>
 
@@ -137,74 +156,23 @@ export default function LandingPage() {
           <Heading size="lg" textAlign="center" mb={10}>
             Enterprise Solutions
           </Heading>
-          <SimpleGrid columns={{ base: 1, md: 3 }} spacing={8}>
-            <Stack
-              spacing={4}
-              p={6}
-              bg="white"
-              borderRadius="md"
-              boxShadow="md"
-              align="center"
-              className={styles.solutionCard}
-            >
-              <Image
-                src="https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1489343511429-5482f78c15cf.jpg"
-                alt="Recruiting suite"
-                className={styles.solutionImage}
-              />
-              <Heading size="md">Recruiting Suite</Heading>
-              <Text textAlign="center">
-                Automate sourcing and streamline applicant tracking with one unified hub.
-              </Text>
-              <Button colorScheme="brand" variant="outline">
-                Learn More
-              </Button>
-            </Stack>
-            <Stack
-              spacing={4}
-              p={6}
-              bg="white"
-              borderRadius="md"
-              boxShadow="md"
-              align="center"
-              className={styles.solutionCard}
-            >
-              <Image
-                src="https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1494253188410-ff0cdea5499e.jpg"
-                alt="Gig marketplace"
-                className={styles.solutionImage}
-              />
-              <Heading size="md">Gig Marketplace</Heading>
-              <Text textAlign="center">
-                Connect freelancers and employers with secure contracts and messaging.
-              </Text>
-              <Button colorScheme="brand" variant="outline">
-                Explore
-              </Button>
-            </Stack>
-            <Stack
-              spacing={4}
-              p={6}
-              bg="white"
-              borderRadius="md"
-              boxShadow="md"
-              align="center"
-              className={styles.solutionCard}
-            >
-              <Image
-                src="https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1504888302758-9adb6780e7c8.jpg"
-                alt="Analytics portal"
-                className={styles.solutionImage}
-              />
-              <Heading size="md">Analytics Portal</Heading>
-              <Text textAlign="center">
-                Visualize performance trends and make data-driven decisions instantly.
-              </Text>
-              <Button colorScheme="brand" variant="outline">
-                View Dashboard
-              </Button>
-            </Stack>
-          </SimpleGrid>
+          {loadingContent ? (
+            <Flex justify="center" py={10}>
+              <Spinner />
+            </Flex>
+          ) : (
+            <SimpleGrid columns={{ base: 1, md: 3 }} spacing={8}>
+              {solutions.map((s) => (
+                <SolutionCard
+                  key={s.id}
+                  title={s.title}
+                  description={s.description}
+                  imageUrl={s.imageUrl}
+                  ctaText={s.ctaText || undefined}
+                />
+              ))}
+            </SimpleGrid>
+          )}
         </Container>
       </Box>
 

--- a/components/FeatureCard.module.css
+++ b/components/FeatureCard.module.css
@@ -1,0 +1,13 @@
+.card {
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.image {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  border-radius: 8px;
+}

--- a/components/FeatureCard.tsx
+++ b/components/FeatureCard.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Stack, Heading, Text, Image } from "@chakra-ui/react";
+import styles from "./FeatureCard.module.css";
+
+interface Props {
+  title: string;
+  description: string;
+  imageUrl: string;
+}
+
+export default function FeatureCard({ title, description, imageUrl }: Props) {
+  return (
+    <Stack align="center" spacing={3} className={styles.card}>
+      <Image src={imageUrl} alt={title} className={styles.image} />
+      <Heading size="md">{title}</Heading>
+      <Text textAlign="center">{description}</Text>
+    </Stack>
+  );
+}

--- a/components/SolutionCard.module.css
+++ b/components/SolutionCard.module.css
@@ -1,0 +1,14 @@
+.card {
+  transition: transform 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+}
+
+.image {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  border-radius: 8px;
+}

--- a/components/SolutionCard.tsx
+++ b/components/SolutionCard.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Stack, Image, Heading, Text, Button } from "@chakra-ui/react";
+import styles from "./SolutionCard.module.css";
+
+interface Props {
+  title: string;
+  description: string;
+  imageUrl: string;
+  ctaText?: string;
+}
+
+export default function SolutionCard({ title, description, imageUrl, ctaText }: Props) {
+  return (
+    <Stack
+      spacing={4}
+      p={6}
+      bg="white"
+      borderRadius="md"
+      boxShadow="md"
+      align="center"
+      className={styles.card}
+    >
+      <Image src={imageUrl} alt={title} className={styles.image} />
+      <Heading size="md">{title}</Heading>
+      <Text textAlign="center">{description}</Text>
+      {ctaText && (
+        <Button colorScheme="brand" variant="outline">
+          {ctaText}
+        </Button>
+      )}
+    </Stack>
+  );
+}

--- a/prisma/migrations/20250315000006_add_features_solutions/migration.sql
+++ b/prisma/migrations/20250315000006_add_features_solutions/migration.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "Feature" (
+  "id" SERIAL PRIMARY KEY,
+  "title" TEXT NOT NULL,
+  "description" TEXT NOT NULL,
+  "imageUrl" TEXT NOT NULL
+);
+
+CREATE TABLE "Solution" (
+  "id" SERIAL PRIMARY KEY,
+  "title" TEXT NOT NULL,
+  "description" TEXT NOT NULL,
+  "imageUrl" TEXT NOT NULL,
+  "ctaText" TEXT
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,21 @@ model Testimonial {
   avatarUrl String?
 }
 
+model Feature {
+  id          Int    @id @default(autoincrement())
+  title       String
+  description String
+  imageUrl    String
+}
+
+model Solution {
+  id          Int    @id @default(autoincrement())
+  title       String
+  description String
+  imageUrl    String
+  ctaText     String?
+}
+
 model Project {
   id        Int      @id @default(autoincrement())
   title     String

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -39,6 +39,51 @@ async function main() {
     skipDuplicates: true,
   });
 
+  await prisma.feature.createMany({
+    data: [
+      {
+        title: 'AI-Powered Matching',
+        description: 'Connect with the right opportunities using intelligent algorithms.',
+        imageUrl: 'https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1456244440184-1d494704a505.jpg',
+      },
+      {
+        title: 'Integrated Gig Management',
+        description: 'Manage tasks and projects seamlessly in one place.',
+        imageUrl: 'https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1500393734221-584dd6dbf92a.jpg',
+      },
+      {
+        title: 'Real-Time Analytics',
+        description: 'Gain insights with up-to-the-minute data and reports.',
+        imageUrl: 'https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1462332420958-a05d1e002413.jpg',
+      },
+    ],
+    skipDuplicates: true,
+  });
+
+  await prisma.solution.createMany({
+    data: [
+      {
+        title: 'Recruiting Suite',
+        description: 'Automate sourcing and streamline applicant tracking with one unified hub.',
+        imageUrl: 'https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1489343511429-5482f78c15cf.jpg',
+        ctaText: 'Learn More',
+      },
+      {
+        title: 'Gig Marketplace',
+        description: 'Connect freelancers and employers with secure contracts and messaging.',
+        imageUrl: 'https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1494253188410-ff0cdea5499e.jpg',
+        ctaText: 'Explore',
+      },
+      {
+        title: 'Analytics Portal',
+        description: 'Visualize performance trends and make data-driven decisions instantly.',
+        imageUrl: 'https://raw.githubusercontent.com/ServiceStack/images/master/hero/photo-1504888302758-9adb6780e7c8.jpg',
+        ctaText: 'View Dashboard',
+      },
+    ],
+    skipDuplicates: true,
+  });
+
   const admin = await prisma.user.findUnique({
     where: { email: 'jamahlthomas1996@gmail.com' },
   });


### PR DESCRIPTION
## Summary
- serve home page feature and solution data from new Feature and Solution tables
- display landing cards via reusable components powered by backend APIs
- seed database and expose /api/features and /api/solutions endpoints

## Testing
- `npx prisma generate`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689588050e548320a436a1e6d1179637