### PR TITLE
feat: add financial media onboarding step

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -17,6 +17,7 @@ export async function POST(req: Request) {
       portfolio: data.portfolio,
       title: data.title,
       image: data.image,
+      introVideo: data.introVideo,
       resume: data.resume,
       coverLetter: data.coverLetter,
     });

--- a/app/signup/documents/page.tsx
+++ b/app/signup/documents/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { useSignup } from "@/components/SignupContext";
+import { fileToBase64 } from "@/lib/utils/file";
 import styles from "./page.module.css";
 
 export default function DocumentsPage() {
@@ -24,12 +25,11 @@ export default function DocumentsPage() {
   const [error, setError] = useState("");
   const router = useRouter();
 
-  const handleResume = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleResume = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    const reader = new FileReader();
-    reader.onload = () => setResume(reader.result as string);
-    reader.readAsDataURL(file);
+    const base64 = await fileToBase64(file);
+    setResume(base64);
   };
 
   const handleSubmit = async () => {

--- a/app/signup/financial/page.module.css
+++ b/app/signup/financial/page.module.css
@@ -1,3 +1,8 @@
 .container {
   background-color: white;
 }
+
+.fileInput {
+  border: 1px dashed #ccc;
+  padding: 8px;
+}

--- a/app/signup/financial/page.tsx
+++ b/app/signup/financial/page.tsx
@@ -1,9 +1,20 @@
 "use client";
 
 import { useState } from "react";
-import { Box, Input, Stack, Heading, Button, Textarea, Progress } from "@chakra-ui/react";
+import {
+  Box,
+  Input,
+  Stack,
+  Heading,
+  Button,
+  Textarea,
+  Progress,
+  FormControl,
+  FormErrorMessage,
+} from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { useSignup } from "@/components/SignupContext";
+import { fileToBase64 } from "@/lib/utils/file";
 import styles from "./page.module.css";
 
 export default function FinancialPage() {
@@ -15,26 +26,36 @@ export default function FinancialPage() {
     portfolio: data.portfolio || "",
     title: data.title || "",
     image: data.image || "",
+    video: data.introVideo || "",
   });
+  const [cardError, setCardError] = useState("");
 
   const router = useRouter();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
     setForm((prev) => ({ ...prev, [name]: value }));
+    if (name === "payment") {
+      const valid = /^\d{16}$/.test(value.replace(/\s+/g, ""));
+      setCardError(valid || !value ? "" : "Invalid card number");
+    }
   };
 
-  const handleImage = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    const reader = new FileReader();
-    reader.onload = () => {
-      setForm((prev) => ({ ...prev, image: reader.result as string }));
-    };
-    reader.readAsDataURL(file);
+    const base64 = await fileToBase64(file);
+    setForm((prev) => ({ ...prev, image: base64 }));
   };
 
-  const canSubmit = form.payment && form.title;
+  const handleVideo = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const base64 = await fileToBase64(file);
+    setForm((prev) => ({ ...prev, video: base64 }));
+  };
+
+  const canSubmit = form.payment && !cardError && form.title;
 
   const handleNext = () => {
     setData({
@@ -44,6 +65,7 @@ export default function FinancialPage() {
       portfolio: form.portfolio,
       title: form.title,
       image: form.image,
+      introVideo: form.video,
     });
     router.push("/signup/documents");
   };
@@ -63,9 +85,32 @@ export default function FinancialPage() {
         Step 2 of 3
       </Heading>
       <Stack spacing={4}>
-        <Input placeholder="Payment Method" name="payment" value={form.payment} onChange={handleChange} />
+        <FormControl isInvalid={!!cardError}>
+          <Input
+            placeholder="Card Number"
+            name="payment"
+            value={form.payment}
+            onChange={handleChange}
+            inputMode="numeric"
+            maxLength={16}
+          />
+          {cardError && <FormErrorMessage>{cardError}</FormErrorMessage>}
+        </FormControl>
         <Input placeholder="Tax ID (optional)" name="tax" value={form.tax} onChange={handleChange} />
-        <Input type="file" accept="image/*" name="picture" onChange={handleImage} />
+        <Input
+          type="file"
+          accept="image/*"
+          name="picture"
+          onChange={handleImage}
+          className={styles.fileInput}
+        />
+        <Input
+          type="file"
+          accept="video/*"
+          name="video"
+          onChange={handleVideo}
+          className={styles.fileInput}
+        />
         <Textarea placeholder="Bio (250 chars)" name="bio" value={form.bio} onChange={handleChange} maxLength={250} />
         <Input placeholder="Portfolio Link" name="portfolio" value={form.portfolio} onChange={handleChange} />
         <Input placeholder="Profile Title" name="title" value={form.title} onChange={handleChange} />

--- a/components/SignupContext.tsx
+++ b/components/SignupContext.tsx
@@ -15,6 +15,7 @@ export type SignupData = {
   portfolio?: string;
   title?: string;
   image?: string;
+  introVideo?: string;
   resume?: string;
   coverLetter?: string;
 };

--- a/lib/controllers/authController.ts
+++ b/lib/controllers/authController.ts
@@ -13,6 +13,7 @@ export async function register(data: {
   portfolio?: string;
   title?: string;
   image?: string;
+  introVideo?: string;
   resume?: string;
   coverLetter?: string;
 }) {

--- a/lib/services/authService.ts
+++ b/lib/services/authService.ts
@@ -18,6 +18,7 @@ export async function registerUser(data: {
   portfolio?: string;
   title?: string;
   image?: string;
+  introVideo?: string;
   resume?: string;
   coverLetter?: string;
 }) {
@@ -38,6 +39,7 @@ export async function registerUser(data: {
       portfolio: data.portfolio,
       title: data.title,
       image: data.image,
+      introVideo: data.introVideo,
       resume: data.resume,
       coverLetter: data.coverLetter,
     },

--- a/lib/services/userService.ts
+++ b/lib/services/userService.ts
@@ -16,6 +16,7 @@ export async function getUserProfile(email: string) {
       portfolio: true,
       title: true,
       image: true,
+      introVideo: true,
       resume: true,
       coverLetter: true,
     },
@@ -33,6 +34,7 @@ export interface UpdateProfileData {
   portfolio?: string;
   title?: string;
   image?: string;
+  introVideo?: string;
   resume?: string;
   coverLetter?: string;
 }
@@ -54,6 +56,7 @@ export async function updateUserProfile(email: string, data: UpdateProfileData) 
       portfolio: true,
       title: true,
       image: true,
+      introVideo: true,
       resume: true,
       coverLetter: true,
     },

--- a/lib/utils/file.ts
+++ b/lib/utils/file.ts
@@ -1,0 +1,14 @@
+export async function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+      } else {
+        reject(new Error("Failed to convert file"));
+      }
+    };
+    reader.onerror = () => reject(reader.error || new Error("File reading error"));
+    reader.readAsDataURL(file);
+  });
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model User {
   portfolio        String?
   title            String?
   image            String?
+  introVideo       String?
   resume           String?
   coverLetter      String?
   notifications    Notification[]


### PR DESCRIPTION
## Summary
- allow new users to upload profile videos during signup
- add file reader utility and card number validation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68958822e8d083208a8a5952f82afa22