### PR TITLE
feat: add document onboarding with ai

### DIFF
--- a/app/(dashboard)/onboarding/documents/page.module.css
+++ b/app/(dashboard)/onboarding/documents/page.module.css
@@ -1,3 +1,7 @@
 .container {
   background-color: white;
 }
+
+.section {
+  margin-bottom: 1rem;
+}

--- a/app/api/ai/cover-letter/route.ts
+++ b/app/api/ai/cover-letter/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const { profile, template } = await req.json();
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: "AI service not configured" }, { status: 500 });
+  }
+  const prompt = `Write a concise cover letter using the following profile information: ${JSON.stringify(
+    profile
+  )}. Base the tone on this template: ${template}`;
+  const response = await fetch(
+    process.env.OPENAI_API_URL || "https://api.openai.com/v1/chat/completions",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages: [{ role: "user", content: prompt }],
+      }),
+    }
+  );
+  if (!response.ok) {
+    return NextResponse.json({ error: "AI request failed" }, { status: 500 });
+  }
+  const data = await response.json();
+  const coverLetter = data.choices?.[0]?.message?.content?.trim() || "";
+  return NextResponse.json({ coverLetter });
+}

--- a/app/api/ai/cv/route.ts
+++ b/app/api/ai/cv/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const { profile } = await req.json();
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: "AI service not configured" }, { status: 500 });
+  }
+  const prompt = `Create a professional CV in plain text using the following information: ${JSON.stringify(
+    profile
+  )}. Include sections for Summary, Experience, Education and Skills.`;
+  const response = await fetch(
+    process.env.OPENAI_API_URL || "https://api.openai.com/v1/chat/completions",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages: [{ role: "user", content: prompt }],
+      }),
+    }
+  );
+  if (!response.ok) {
+    return NextResponse.json({ error: "AI request failed" }, { status: 500 });
+  }
+  const data = await response.json();
+  const cv = data.choices?.[0]?.message?.content?.trim() || "";
+  return NextResponse.json({ cv });
+}

--- a/app/api/user/cover-letter/upload/route.ts
+++ b/app/api/user/cover-letter/upload/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { updateUserProfile } from "@/lib/services/userService";
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { coverLetter } = await req.json();
+  const updated = await updateUserProfile(session.user.email, { coverLetter });
+  return NextResponse.json({ coverLetter: updated.coverLetter });
+}

--- a/app/api/user/cv/upload/route.ts
+++ b/app/api/user/cv/upload/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { updateUserProfile } from "@/lib/services/userService";
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { cv } = await req.json();
+  const updated = await updateUserProfile(session.user.email, { resume: cv });
+  return NextResponse.json({ resume: updated.resume });
+}

--- a/app/api/user/profile/ai-cover-letter/route.ts
+++ b/app/api/user/profile/ai-cover-letter/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getUserProfile } from "@/lib/services/userService";
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { template } = await req.json();
+  const profile = await getUserProfile(session.user.email);
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: "AI service not configured" }, { status: 500 });
+  }
+  const prompt = `Write a concise cover letter using the following profile information: ${JSON.stringify(
+    profile
+  )}. Base the tone on this template: ${template}`;
+  const response = await fetch(
+    process.env.OPENAI_API_URL || "https://api.openai.com/v1/chat/completions",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages: [{ role: "user", content: prompt }],
+      }),
+    }
+  );
+  if (!response.ok) {
+    return NextResponse.json({ error: "AI request failed" }, { status: 500 });
+  }
+  const data = await response.json();
+  const coverLetter = data.choices?.[0]?.message?.content?.trim() || "";
+  return NextResponse.json({ coverLetter });
+}

--- a/app/api/user/profile/ai-cv/route.ts
+++ b/app/api/user/profile/ai-cv/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getUserProfile } from "@/lib/services/userService";
+
+export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const profile = await getUserProfile(session.user.email);
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: "AI service not configured" }, { status: 500 });
+  }
+  const prompt = `Create a professional CV in plain text using the following information: ${JSON.stringify(
+    profile
+  )}. Include sections for Summary, Experience, Education and Skills.`;
+  const response = await fetch(
+    process.env.OPENAI_API_URL || "https://api.openai.com/v1/chat/completions",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages: [{ role: "user", content: prompt }],
+      }),
+    }
+  );
+  if (!response.ok) {
+    return NextResponse.json({ error: "AI request failed" }, { status: 500 });
+  }
+  const data = await response.json();
+  const cv = data.choices?.[0]?.message?.content?.trim() || "";
+  return NextResponse.json({ cv });
+}

--- a/app/signup/documents/page.module.css
+++ b/app/signup/documents/page.module.css
@@ -1,3 +1,7 @@
 .container {
   background-color: white;
 }
+
+.section {
+  margin-bottom: 1rem;
+}

--- a/app/signup/documents/page.tsx
+++ b/app/signup/documents/page.tsx
@@ -11,7 +11,13 @@ import {
   Progress,
   Alert,
   AlertIcon,
+  RadioGroup,
+  Radio,
+  HStack,
+  Text,
+  useToast,
 } from "@chakra-ui/react";
+import CoverLetterTemplates from "@/components/CoverLetterTemplates";
 import { useRouter } from "next/navigation";
 import { useSignup } from "@/components/SignupContext";
 import styles from "./page.module.css";
@@ -19,17 +25,49 @@ import styles from "./page.module.css";
 export default function DocumentsPage() {
   const { data, setData } = useSignup();
   const [resume, setResume] = useState<string>(data.resume || "");
+  const [resumeMode, setResumeMode] = useState("upload");
   const [coverLetter, setCoverLetter] = useState(data.coverLetter || "");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
   const router = useRouter();
+  const toast = useToast();
 
   const handleResume = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
     const reader = new FileReader();
     reader.onload = () => setResume(reader.result as string);
-    reader.readAsDataURL(file);
+    reader.readAsText(file);
+  };
+
+  const generateCv = async () => {
+    try {
+      const res = await fetch("/api/ai/cv", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ profile: data }),
+      });
+      const json = await res.json();
+      setResume(json.cv);
+      toast({ status: "success", title: "CV generated" });
+    } catch (e) {
+      toast({ status: "error", title: "Failed to generate CV" });
+    }
+  };
+
+  const generateCoverLetter = async () => {
+    try {
+      const res = await fetch("/api/ai/cover-letter", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ profile: data, template: coverLetter }),
+      });
+      const json = await res.json();
+      setCoverLetter(json.coverLetter);
+      toast({ status: "success", title: "Cover letter generated" });
+    } catch (e) {
+      toast({ status: "error", title: "Failed to generate cover letter" });
+    }
   };
 
   const handleSubmit = async () => {
@@ -56,7 +94,7 @@ export default function DocumentsPage() {
     }
   };
 
-  const canSubmit = !!resume;
+  const canSubmit = !!resume && !!coverLetter;
 
   return (
     <Box
@@ -72,19 +110,65 @@ export default function DocumentsPage() {
       <Heading size="md" mb={6} textAlign="center">
         Step 3 of 3
       </Heading>
-      <Stack spacing={4}>
+      <Stack spacing={6}>
         {error && (
           <Alert status="error">
             <AlertIcon />
             {error}
           </Alert>
         )}
-        <Input type="file" accept=".pdf,.doc,.docx" onChange={handleResume} />
-        <Textarea
-          placeholder="Cover Letter"
-          value={coverLetter}
-          onChange={(e) => setCoverLetter(e.target.value)}
-        />
+
+        <Box className={styles.section}>
+          <Heading size="sm" mb={2}>
+            Upload or Generate Your CV
+          </Heading>
+          <RadioGroup
+            onChange={setResumeMode}
+            value={resumeMode}
+            mb={3}
+          >
+            <HStack spacing={4}>
+              <Radio value="upload">Upload</Radio>
+              <Radio value="ai">Generate with AI</Radio>
+            </HStack>
+          </RadioGroup>
+          {resumeMode === "upload" ? (
+            <Input type="file" accept=".pdf,.doc,.docx,.txt" onChange={handleResume} />
+          ) : (
+            <Button onClick={generateCv} colorScheme="brand" mb={2}>
+              Generate CV
+            </Button>
+          )}
+          <Textarea
+            placeholder="CV Content"
+            value={resume}
+            onChange={(e) => setResume(e.target.value)}
+            minH="150px"
+          />
+          {resume && (
+            <Text fontSize="sm" color="gray.600" mt={1}>
+              Word Count: {resume.split(/\s+/).filter(Boolean).length}
+            </Text>
+          )}
+        </Box>
+
+        <Box className={styles.section}>
+          <Heading size="sm" mb={2}>
+            Cover Letter
+          </Heading>
+          <CoverLetterTemplates value={coverLetter} onChange={setCoverLetter} />
+          <Textarea
+            mt={3}
+            placeholder="Cover Letter"
+            value={coverLetter}
+            onChange={(e) => setCoverLetter(e.target.value)}
+            minH="150px"
+          />
+          <Button mt={2} onClick={generateCoverLetter} colorScheme="brand">
+            Generate Cover Letter
+          </Button>
+        </Box>
+
         <Button
           colorScheme="brand"
           onClick={handleSubmit}

--- a/components/CoverLetterTemplates.module.css
+++ b/components/CoverLetterTemplates.module.css
@@ -1,0 +1,6 @@
+.preview {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 12px;
+  background-color: #f7fafc;
+}

--- a/components/CoverLetterTemplates.tsx
+++ b/components/CoverLetterTemplates.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import { Box, Select, Text } from "@chakra-ui/react";
+import styles from "./CoverLetterTemplates.module.css";
+
+export interface TemplateOption {
+  name: string;
+  value: string;
+}
+
+const defaultTemplates: TemplateOption[] = [
+  {
+    name: "Technology",
+    value:
+      "Dear Hiring Manager,\n\nI am excited to apply for the technology role at your company. My experience in software development and problem-solving makes me a strong candidate.\n\nSincerely,\n[Your Name]",
+  },
+  {
+    name: "Marketing",
+    value:
+      "Dear Marketing Team,\n\nWith a passion for crafting compelling campaigns and a track record of driving engagement, I would love to contribute to your marketing initiatives.\n\nBest regards,\n[Your Name]",
+  },
+  {
+    name: "Finance",
+    value:
+      "Dear Finance Department,\n\nMy background in financial analysis and budgeting has prepared me to add value to your finance team. I am eager to bring my skills to your organization.\n\nThank you,\n[Your Name]",
+  },
+];
+
+interface Props {
+  templates?: TemplateOption[];
+  value: string;
+  onChange: (content: string) => void;
+}
+
+export default function CoverLetterTemplates({
+  templates = defaultTemplates,
+  value,
+  onChange,
+}: Props) {
+  const [preview, setPreview] = useState(value);
+
+  const handleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selected = templates.find((t) => t.name === e.target.value);
+    const content = selected ? selected.value : "";
+    setPreview(content);
+    onChange(content);
+  };
+
+  return (
+    <Box>
+      <Select placeholder="Select Template" onChange={handleSelect} mb={3}>
+        {templates.map((t) => (
+          <option key={t.name} value={t.name}>
+            {t.name}
+          </option>
+        ))}
+      </Select>
+      {preview && (
+        <Box className={styles.preview}>
+          <Text whiteSpace="pre-wrap" fontSize="sm">
+            {preview}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+}
+


### PR DESCRIPTION
## Summary
- enhance document onboarding pages with CV generation, cover letter templates, and word count feedback
- add CoverLetterTemplates component for industry-based cover letter previews
- implement API routes for AI document generation and secure uploads

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895882fc92c8320b42a66a071d0a358