### PR TITLE
Add profile customization settings

### DIFF
--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -17,7 +17,43 @@ export async function PUT(req: Request) {
   if (!session?.user?.email) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
-  const data = await req.json();
-  const updated = await updateUserProfile(session.user.email, data);
+  const {
+    name,
+    phone,
+    location,
+    bio,
+    expertise,
+    payment,
+    taxId,
+    portfolio,
+    title,
+    image,
+    resume,
+    coverLetter,
+    showPortfolio,
+    showReviews,
+    showActivityFeed,
+    themeColor,
+    bannerUrl,
+  } = await req.json();
+  const updated = await updateUserProfile(session.user.email, {
+    name,
+    phone,
+    location,
+    bio,
+    expertise,
+    payment,
+    taxId,
+    portfolio,
+    title,
+    image,
+    resume,
+    coverLetter,
+    showPortfolio,
+    showReviews,
+    showActivityFeed,
+    themeColor,
+    bannerUrl,
+  });
   return NextResponse.json(updated);
 }

--- a/app/profile/customize/page.module.css
+++ b/app/profile/customize/page.module.css
@@ -1,0 +1,14 @@
+.container {
+  max-width: 900px;
+  margin: 2rem auto;
+  background: white;
+  padding: 2rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 0 10px rgba(0,0,0,0.05);
+}
+
+.preview {
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  overflow: hidden;
+}

--- a/app/profile/customize/page.tsx
+++ b/app/profile/customize/page.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Box,
+  Stack,
+  FormControl,
+  FormLabel,
+  Switch,
+  Input,
+  Button,
+  Image,
+  Heading,
+  Text,
+} from "@chakra-ui/react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import api from "@/lib/api";
+import styles from "./page.module.css";
+
+interface CustomizationForm {
+  showPortfolio: boolean;
+  showReviews: boolean;
+  showActivityFeed: boolean;
+  themeColor: string;
+  bannerUrl: string;
+}
+
+export default function CustomizeProfilePage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const [form, setForm] = useState<CustomizationForm>({
+    showPortfolio: true,
+    showReviews: true,
+    showActivityFeed: true,
+    themeColor: "#3182ce",
+    bannerUrl: "",
+  });
+
+  useEffect(() => {
+    if (status === "unauthenticated") router.push("/login");
+    if (status === "authenticated") {
+      api.get<CustomizationForm>("/profile").then((data) =>
+        setForm((prev) => ({
+          ...prev,
+          showPortfolio: data.showPortfolio ?? true,
+          showReviews: data.showReviews ?? true,
+          showActivityFeed: data.showActivityFeed ?? true,
+          themeColor: data.themeColor || "#3182ce",
+          bannerUrl: data.bannerUrl || "",
+        }))
+      );
+    }
+  }, [status, router]);
+
+  const handleToggle = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, checked } = e.target;
+    setForm((prev) => ({ ...prev, [name]: checked }));
+  };
+
+  const handleColor = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm((prev) => ({ ...prev, themeColor: e.target.value }));
+  };
+
+  const handleBanner = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file && file.type.startsWith("image/")) {
+      const reader = new FileReader();
+      reader.onload = (ev) =>
+        setForm((prev) => ({ ...prev, bannerUrl: ev.target?.result as string }));
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleSubmit = async () => {
+    await api.put("/profile", form);
+    router.push("/profile");
+  };
+
+  return (
+    <Box className={styles.container}>
+      <Stack spacing={6}>
+        <Stack spacing={4}>
+          <FormControl display="flex" alignItems="center">
+            <FormLabel htmlFor="showPortfolio" mb="0">
+              Show Portfolio
+            </FormLabel>
+            <Switch
+              id="showPortfolio"
+              name="showPortfolio"
+              isChecked={form.showPortfolio}
+              onChange={handleToggle}
+            />
+          </FormControl>
+          <FormControl display="flex" alignItems="center">
+            <FormLabel htmlFor="showReviews" mb="0">
+              Show Reviews
+            </FormLabel>
+            <Switch
+              id="showReviews"
+              name="showReviews"
+              isChecked={form.showReviews}
+              onChange={handleToggle}
+            />
+          </FormControl>
+          <FormControl display="flex" alignItems="center">
+            <FormLabel htmlFor="showActivityFeed" mb="0">
+              Show Activity Feed
+            </FormLabel>
+            <Switch
+              id="showActivityFeed"
+              name="showActivityFeed"
+              isChecked={form.showActivityFeed}
+              onChange={handleToggle}
+            />
+          </FormControl>
+          <FormControl>
+            <FormLabel htmlFor="themeColor">Theme Color</FormLabel>
+            <Input
+              id="themeColor"
+              type="color"
+              value={form.themeColor}
+              onChange={handleColor}
+              maxW="120px"
+            />
+          </FormControl>
+          <FormControl>
+            <FormLabel htmlFor="banner">Profile Banner</FormLabel>
+            <Input id="banner" type="file" accept="image/*" onChange={handleBanner} />
+          </FormControl>
+          <Button colorScheme="brand" onClick={handleSubmit}>
+            Save Changes
+          </Button>
+        </Stack>
+        <Box className={styles.preview} bg="white">
+          {form.bannerUrl && (
+            <Image src={form.bannerUrl} alt="Banner" w="100%" h="200px" objectFit="cover" />
+          )}
+          <Box p={4}>
+            <Heading size="md" color={form.themeColor}>
+              {session?.user?.name || "Your Name"}
+            </Heading>
+            {form.showPortfolio && <Text mt={2}>Portfolio section preview...</Text>}
+            {form.showReviews && <Text mt={2}>Reviews section preview...</Text>}
+            {form.showActivityFeed && <Text mt={2}>Activity feed preview...</Text>}
+          </Box>
+        </Box>
+      </Stack>
+    </Box>
+  );
+}
+

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -15,9 +15,14 @@ export default async function ProfilePage() {
         <Avatar name={user?.name || "User"} src={user?.image || undefined} size="xl" />
         <Heading size="md">{user?.name}</Heading>
         <Text>{user?.email}</Text>
-        <Button as={Link} href="/profile/edit" colorScheme="brand">
-          Edit Profile
-        </Button>
+        <Stack direction="row" spacing={4}>
+          <Button as={Link} href="/profile/edit" colorScheme="brand">
+            Edit Profile
+          </Button>
+          <Button as={Link} href="/profile/customize" variant="outline" colorScheme="brand">
+            Customize
+          </Button>
+        </Stack>
       </Stack>
     </Box>
   );

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -70,6 +70,9 @@ export default function Navbar() {
             <MenuItem as={Link} href="/profile/edit">
               Edit Profile
             </MenuItem>
+            <MenuItem as={Link} href="/profile/customize">
+              Customize Profile
+            </MenuItem>
             <MenuItem as={Link} href="/billing">
               Billing
             </MenuItem>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -13,6 +13,7 @@ export default function Sidebar() {
     { href: "/onboarding", label: "Onboarding" },
     { href: "/profile", label: "Profile" },
     { href: "/profile/edit", label: "Edit Profile" },
+    { href: "/profile/customize", label: "Customize Profile" },
     { href: "/billing", label: "Billing" },
     { href: "/notifications", label: "Notifications" },
     { href: "/messages", label: "Messages" },

--- a/lib/services/userService.ts
+++ b/lib/services/userService.ts
@@ -18,6 +18,11 @@ export async function getUserProfile(email: string) {
       image: true,
       resume: true,
       coverLetter: true,
+      showPortfolio: true,
+      showReviews: true,
+      showActivityFeed: true,
+      themeColor: true,
+      bannerUrl: true,
     },
   });
 }
@@ -35,6 +40,11 @@ export interface UpdateProfileData {
   image?: string;
   resume?: string;
   coverLetter?: string;
+  showPortfolio?: boolean;
+  showReviews?: boolean;
+  showActivityFeed?: boolean;
+  themeColor?: string;
+  bannerUrl?: string;
 }
 
 export async function updateUserProfile(email: string, data: UpdateProfileData) {
@@ -56,6 +66,11 @@ export async function updateUserProfile(email: string, data: UpdateProfileData) 
       image: true,
       resume: true,
       coverLetter: true,
+      showPortfolio: true,
+      showReviews: true,
+      showActivityFeed: true,
+      themeColor: true,
+      bannerUrl: true,
     },
   });
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,11 @@ model User {
   image            String?
   resume           String?
   coverLetter      String?
+  showPortfolio    Boolean? @default(true)
+  showReviews      Boolean? @default(true)
+  showActivityFeed Boolean? @default(true)
+  themeColor       String?
+  bannerUrl        String?
   notifications    Notification[]
   projects         Project[]
   subscriptions    Subscription[]


### PR DESCRIPTION
## Summary
- add profile customization page with theme, banner, and visibility toggles
- store customization settings on user model and expose via profile API
- link customization page in profile and dashboard navigation

## Testing
- `npx prisma generate`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689588405d3883209e48f3157b8ea468