### PR TITLE
feat: add application and interview management

### DIFF
--- a/app/(dashboard)/applications/page.module.css
+++ b/app/(dashboard)/applications/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  width: 100%;
+}

--- a/app/(dashboard)/applications/page.tsx
+++ b/app/(dashboard)/applications/page.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Box,
+  Tabs,
+  TabList,
+  Tab,
+  TabPanels,
+  TabPanel,
+  VStack,
+  useToast,
+} from "@chakra-ui/react";
+import ApplicationItem from "@/components/ApplicationItem";
+import InterviewItem from "@/components/InterviewItem";
+import api from "@/lib/api";
+import styles from "./page.module.css";
+
+interface Interview {
+  id: number;
+  scheduledAt: string;
+  location?: string;
+  link?: string;
+  status: string;
+}
+
+interface Application {
+  id: number;
+  status: string;
+  job: { title: string };
+  applicant?: { name: string };
+  interviews: Interview[];
+}
+
+export default function ApplicationsPage() {
+  const [applications, setApplications] = useState<Application[]>([]);
+  const toast = useToast();
+
+  useEffect(() => {
+    api
+      .get<Application[]>("/applications")
+      .then(setApplications)
+      .catch(() =>
+        toast({ status: "error", title: "Failed to load applications" })
+      );
+  }, [toast]);
+
+  const handleStatusChange = async (id: number, status: string) => {
+    await api.put(`/applications/${id}/status`, { status });
+    setApplications((apps) =>
+      apps.map((a) => (a.id === id ? { ...a, status } : a))
+    );
+  };
+
+  const handleSchedule = async (id: number) => {
+    const scheduledAt = new Date(Date.now() + 3600 * 1000).toISOString();
+    const interview = await api.post(`/applications/${id}/interviews`, {
+      scheduledAt,
+    });
+    setApplications((apps) =>
+      apps.map((a) =>
+        a.id === id ? { ...a, interviews: [...a.interviews, interview] } : a
+      )
+    );
+  };
+
+  const interviews = applications.flatMap((app) =>
+    app.interviews.map((i) => ({ ...i, jobTitle: app.job.title }))
+  );
+
+  return (
+    <Box className={styles.container}>
+      <Tabs>
+        <TabList>
+          <Tab>Applications</Tab>
+          <Tab>Interviews</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <VStack spacing={4} align="stretch">
+              {applications.map((app) => (
+                <ApplicationItem
+                  key={app.id}
+                  id={app.id}
+                  jobTitle={app.job.title}
+                  status={app.status}
+                  onStatusChange={(s) => handleStatusChange(app.id, s)}
+                  onSchedule={() => handleSchedule(app.id)}
+                />
+              ))}
+            </VStack>
+          </TabPanel>
+          <TabPanel>
+            <VStack spacing={4} align="stretch">
+              {interviews.map((inter) => (
+                <InterviewItem
+                  key={inter.id}
+                  jobTitle={(inter as any).jobTitle}
+                  scheduledAt={inter.scheduledAt}
+                  location={inter.location}
+                  link={inter.link}
+                  status={inter.status}
+                />
+              ))}
+            </VStack>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </Box>
+  );
+}

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -57,6 +57,9 @@ export default function DashboardPage() {
         <Button as={Link} href="/messages" colorScheme="brand" variant="outline">
           Messages
         </Button>
+        <Button as={Link} href="/applications" colorScheme="brand" variant="outline">
+          Applications
+        </Button>
       </HStack>
       <SimpleGrid columns={{ base: 1, md: 3 }} spacing={6} mb={10}>
         <DashboardCard title="Users">

--- a/app/api/applications/[id]/interviews/route.ts
+++ b/app/api/applications/[id]/interviews/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { scheduleInterview } from "@/lib/services/applicationService";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { scheduledAt, location, link, notes } = await req.json();
+  if (!scheduledAt) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+  }
+  const interview = await scheduleInterview(Number(params.id), {
+    scheduledAt: new Date(scheduledAt),
+    location,
+    link,
+    notes,
+  });
+  return NextResponse.json(interview, { status: 201 });
+}

--- a/app/api/applications/[id]/status/route.ts
+++ b/app/api/applications/[id]/status/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { updateApplicationStatus } from "@/lib/services/applicationService";
+
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { status } = await req.json();
+  if (!status) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+  }
+  const updated = await updateApplicationStatus(Number(params.id), status);
+  return NextResponse.json(updated);
+}

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import {
+  getMyApplications,
+  getReceivedApplications,
+} from "@/lib/services/applicationService";
+
+export async function GET(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = Number(session.user.id);
+  const { searchParams } = new URL(req.url);
+  const type = searchParams.get("type");
+  const data =
+    type === "received"
+      ? await getReceivedApplications(userId)
+      : await getMyApplications(userId);
+  return NextResponse.json(data);
+}

--- a/components/ApplicationItem.module.css
+++ b/components/ApplicationItem.module.css
@@ -1,0 +1,7 @@
+.item {
+  width: 100%;
+  background-color: #fff;
+}
+.actions {
+  width: 100%;
+}

--- a/components/ApplicationItem.tsx
+++ b/components/ApplicationItem.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Box, HStack, VStack, Text, Button } from "@chakra-ui/react";
+import styles from "./ApplicationItem.module.css";
+
+interface Props {
+  id: number;
+  jobTitle: string;
+  applicantName?: string;
+  status: string;
+  onStatusChange?: (status: string) => void;
+  onSchedule?: () => void;
+}
+
+export default function ApplicationItem({
+  id,
+  jobTitle,
+  applicantName,
+  status,
+  onStatusChange,
+  onSchedule,
+}: Props) {
+  return (
+    <Box className={styles.item} p={4} borderWidth="1px" borderRadius="md" bg="white">
+      <VStack align="start" spacing={2}>
+        <Text fontWeight="bold">{jobTitle}</Text>
+        {applicantName && <Text>Applicant: {applicantName}</Text>}
+        <HStack spacing={2} className={styles.actions}>
+          <Text>Status: {status}</Text>
+          {onStatusChange && (
+            <>
+              <Button size="sm" onClick={() => onStatusChange("accepted")}>Accept</Button>
+              <Button size="sm" onClick={() => onStatusChange("rejected")}>Reject</Button>
+            </>
+          )}
+          {onSchedule && (
+            <Button size="sm" onClick={onSchedule}>Schedule Interview</Button>
+          )}
+        </HStack>
+      </VStack>
+    </Box>
+  );
+}

--- a/components/InterviewItem.module.css
+++ b/components/InterviewItem.module.css
@@ -1,0 +1,7 @@
+.item {
+  width: 100%;
+  background-color: #fff;
+}
+.link {
+  color: #3182ce;
+}

--- a/components/InterviewItem.tsx
+++ b/components/InterviewItem.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Box, VStack, Text } from "@chakra-ui/react";
+import styles from "./InterviewItem.module.css";
+
+interface Props {
+  jobTitle: string;
+  scheduledAt: string;
+  location?: string;
+  link?: string;
+  status: string;
+}
+
+export default function InterviewItem({ jobTitle, scheduledAt, location, link, status }: Props) {
+  return (
+    <Box className={styles.item} p={4} borderWidth="1px" borderRadius="md" bg="white">
+      <VStack align="start" spacing={2}>
+        <Text fontWeight="bold">{jobTitle}</Text>
+        <Text>Scheduled: {new Date(scheduledAt).toLocaleString()}</Text>
+        {location && <Text>Location: {location}</Text>}
+        {link && (
+          <Text>
+            Link: <a href={link} className={styles.link}>{link}</a>
+          </Text>
+        )}
+        <Text>Status: {status}</Text>
+      </VStack>
+    </Box>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -16,6 +16,7 @@ export default function Sidebar() {
     { href: "/billing", label: "Billing" },
     { href: "/notifications", label: "Notifications" },
     { href: "/messages", label: "Messages" },
+    { href: "/applications", label: "Applications" },
     { href: "/gigs", label: "Browse Gigs" },
     { href: "/gig-management", label: "Manage Gigs" },
   ];

--- a/lib/services/applicationService.ts
+++ b/lib/services/applicationService.ts
@@ -1,0 +1,42 @@
+import prisma from "@/lib/prisma";
+
+export async function getMyApplications(userId: number) {
+  return prisma.application.findMany({
+    where: { applicantId: userId },
+    include: {
+      job: true,
+      interviews: true,
+    },
+  });
+}
+
+export async function getReceivedApplications(userId: number) {
+  return prisma.application.findMany({
+    where: { job: { employerId: userId } },
+    include: {
+      applicant: true,
+      job: true,
+      interviews: true,
+    },
+  });
+}
+
+export async function updateApplicationStatus(applicationId: number, status: string) {
+  return prisma.application.update({
+    where: { id: applicationId },
+    data: { status },
+  });
+}
+
+export interface ScheduleInterviewData {
+  scheduledAt: Date;
+  location?: string;
+  link?: string;
+  notes?: string;
+}
+
+export async function scheduleInterview(applicationId: number, data: ScheduleInterviewData) {
+  return prisma.interview.create({
+    data: { ...data, applicationId },
+  });
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,10 +7,16 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum Role {
+  jobSeeker
+  employer
+}
+
 model User {
   id               Int               @id @default(autoincrement())
   name             String?
   email            String            @unique
+  role             Role              @default(jobSeeker)
   password         String
   phone            String?
   location         String?
@@ -132,4 +138,36 @@ model Gig {
   seller      User     @relation(fields: [sellerId], references: [id])
   sellerId    Int
   createdAt   DateTime @default(now())
+}
+
+model Job {
+  id        Int      @id @default(autoincrement())
+  title     String
+  employer  User     @relation(fields: [employerId], references: [id])
+  employerId Int
+  applications Application[]
+  createdAt DateTime @default(now())
+}
+
+model Application {
+  id          Int      @id @default(autoincrement())
+  job         Job      @relation(fields: [jobId], references: [id])
+  jobId       Int
+  applicant   User     @relation(fields: [applicantId], references: [id])
+  applicantId Int
+  status      String   @default("pending")
+  interviews  Interview[]
+  createdAt   DateTime @default(now())
+}
+
+model Interview {
+  id             Int       @id @default(autoincrement())
+  application    Application @relation(fields: [applicationId], references: [id])
+  applicationId  Int
+  scheduledAt    DateTime
+  location       String?
+  link           String?
+  status         String    @default("scheduled")
+  notes          String?
+  createdAt      DateTime  @default(now())
 }


### PR DESCRIPTION
## Summary
- expand Prisma schema with role, job, application, and interview models
- create services and API routes for application tracking and interview scheduling
- build applications dashboard with reusable components and navigation links

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895887ac2f083208a8421ed62c56943