### PR TITLE
feat: add job post management

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -54,6 +54,9 @@ export default function DashboardPage() {
         <Button as={Link} href="/gigs" colorScheme="brand" variant="outline">
           Browse Gigs
         </Button>
+        <Button as={Link} href="/job-posts" colorScheme="brand" variant="outline">
+          Manage Job Posts
+        </Button>
         <Button as={Link} href="/messages" colorScheme="brand" variant="outline">
           Messages
         </Button>

--- a/app/(dashboard)/job-posts/page.module.css
+++ b/app/(dashboard)/job-posts/page.module.css
@@ -1,0 +1,12 @@
+.container {
+  width: 100%;
+}
+
+.preview {
+  background-color: #f9f9f9;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}

--- a/app/(dashboard)/job-posts/page.tsx
+++ b/app/(dashboard)/job-posts/page.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  NumberInput,
+  NumberInputField,
+  Select,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Tag,
+  HStack,
+  VStack,
+  Spinner,
+  Text,
+} from "@chakra-ui/react";
+import api from "@/lib/api";
+import styles from "./page.module.css";
+
+interface JobPost {
+  id: number;
+  title: string;
+  description: string;
+  requirements?: string;
+  salaryMin?: number;
+  salaryMax?: number;
+  benefits?: string;
+  jobType: string;
+  location?: string;
+  deadline?: string;
+  category?: string;
+  status: string;
+}
+
+export default function JobPostManagementPage() {
+  const [posts, setPosts] = useState<JobPost[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [filter, setFilter] = useState("");
+  const [editingId, setEditingId] = useState<number | null>(null);
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [requirements, setRequirements] = useState("");
+  const [salaryMin, setSalaryMin] = useState("");
+  const [salaryMax, setSalaryMax] = useState("");
+  const [benefits, setBenefits] = useState("");
+  const [jobType, setJobType] = useState("full-time");
+  const [location, setLocation] = useState("");
+  const [deadline, setDeadline] = useState("");
+  const [category, setCategory] = useState("");
+
+  const loadPosts = async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      params.set("mine", "true");
+      if (filter) params.set("status", filter);
+      const data = await api.get<JobPost[]>(`/job-posts?${params.toString()}`);
+      setPosts(data);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadPosts();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filter]);
+
+  const resetForm = () => {
+    setTitle("");
+    setDescription("");
+    setRequirements("");
+    setSalaryMin("");
+    setSalaryMax("");
+    setBenefits("");
+    setJobType("full-time");
+    setLocation("");
+    setDeadline("");
+    setCategory("");
+    setEditingId(null);
+  };
+
+  const savePost = async () => {
+    const body = {
+      title,
+      description,
+      requirements: requirements || undefined,
+      salaryMin: salaryMin ? Number(salaryMin) : undefined,
+      salaryMax: salaryMax ? Number(salaryMax) : undefined,
+      benefits: benefits || undefined,
+      jobType,
+      location: location || undefined,
+      deadline: deadline ? new Date(deadline) : undefined,
+      category: category || undefined,
+      status: "active",
+    };
+    if (editingId) {
+      await api.put(`/job-posts/${editingId}`, body);
+    } else {
+      await api.post<JobPost>("/job-posts", body);
+    }
+    resetForm();
+    loadPosts();
+  };
+
+  const editPost = (post: JobPost) => {
+    setEditingId(post.id);
+    setTitle(post.title);
+    setDescription(post.description);
+    setRequirements(post.requirements || "");
+    setSalaryMin(post.salaryMin?.toString() || "");
+    setSalaryMax(post.salaryMax?.toString() || "");
+    setBenefits(post.benefits || "");
+    setJobType(post.jobType);
+    setLocation(post.location || "");
+    setDeadline(post.deadline ? post.deadline.substring(0, 10) : "");
+    setCategory(post.category || "");
+  };
+
+  const duplicatePost = async (post: JobPost) => {
+    const { id, status, deadline, ...rest } = post;
+    await api.post("/job-posts", {
+      ...rest,
+      status,
+      deadline: deadline ? new Date(deadline) : undefined,
+      title: `${post.title} (Copy)`,
+    });
+    loadPosts();
+  };
+
+  const toggleStatus = async (post: JobPost) => {
+    const newStatus = post.status === "active" ? "inactive" : "active";
+    await api.put(`/job-posts/${post.id}`, { status: newStatus });
+    loadPosts();
+  };
+
+  const removePost = async (post: JobPost) => {
+    await api.delete(`/job-posts/${post.id}`);
+    loadPosts();
+  };
+
+  return (
+    <Box className={styles.container}>
+      <VStack align="stretch" spacing={4} mb={8}>
+        <FormControl isRequired>
+          <FormLabel>Job Title</FormLabel>
+          <Input value={title} onChange={(e) => setTitle(e.target.value)} />
+        </FormControl>
+        <FormControl isRequired>
+          <FormLabel>Job Description</FormLabel>
+          <Textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            minH="120px"
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Requirements & Qualifications</FormLabel>
+          <Textarea
+            value={requirements}
+            onChange={(e) => setRequirements(e.target.value)}
+            minH="80px"
+          />
+        </FormControl>
+        <HStack spacing={4} flexWrap="wrap">
+          <FormControl maxW="150px">
+            <FormLabel>Salary Min</FormLabel>
+            <NumberInput min={0} value={salaryMin} onChange={(v) => setSalaryMin(v)}>
+              <NumberInputField />
+            </NumberInput>
+          </FormControl>
+          <FormControl maxW="150px">
+            <FormLabel>Salary Max</FormLabel>
+            <NumberInput min={0} value={salaryMax} onChange={(v) => setSalaryMax(v)}>
+              <NumberInputField />
+            </NumberInput>
+          </FormControl>
+          <FormControl maxW="200px">
+            <FormLabel>Job Type</FormLabel>
+            <Select value={jobType} onChange={(e) => setJobType(e.target.value)}>
+              <option value="full-time">Full-time</option>
+              <option value="part-time">Part-time</option>
+              <option value="remote">Remote</option>
+              <option value="contract">Contract</option>
+              <option value="gig">Gig</option>
+            </Select>
+          </FormControl>
+          <FormControl maxW="200px">
+            <FormLabel>Location</FormLabel>
+            <Input value={location} onChange={(e) => setLocation(e.target.value)} />
+          </FormControl>
+          <FormControl maxW="200px">
+            <FormLabel>Application Deadline</FormLabel>
+            <Input type="date" value={deadline} onChange={(e) => setDeadline(e.target.value)} />
+          </FormControl>
+          <FormControl maxW="200px">
+            <FormLabel>Industry Category</FormLabel>
+            <Input value={category} onChange={(e) => setCategory(e.target.value)} />
+          </FormControl>
+        </HStack>
+        <FormControl>
+          <FormLabel>Benefits</FormLabel>
+          <Input value={benefits} onChange={(e) => setBenefits(e.target.value)} />
+        </FormControl>
+        <HStack spacing={4}>
+          <Button colorScheme="brand" onClick={savePost}>
+            {editingId ? "Update Job Post" : "Create Job Post"}
+          </Button>
+          {editingId && (
+            <Button variant="ghost" onClick={resetForm}>
+              Cancel
+            </Button>
+          )}
+        </HStack>
+      </VStack>
+
+      <Box className={styles.preview} p={4} borderWidth="1px" borderRadius="md" mb={10}>
+        <Text fontSize="xl" fontWeight="bold" mb={2}>
+          {title || "Job Title Preview"}
+        </Text>
+        <Text mb={2}>{description || "Job description preview"}</Text>
+        {requirements && (
+          <Text mb={2}>
+            <strong>Requirements:</strong> {requirements}
+          </Text>
+        )}
+        {(salaryMin || salaryMax) && (
+          <Text mb={2}>
+            <strong>Salary:</strong> {salaryMin || ""} - {salaryMax || ""}
+          </Text>
+        )}
+        {location && (
+          <Text mb={2}>
+            <strong>Location:</strong> {location}
+          </Text>
+        )}
+        {deadline && (
+          <Text>
+            <strong>Apply by:</strong> {deadline}
+          </Text>
+        )}
+      </Box>
+
+      <HStack mb={4} spacing={4} align="center">
+        <FormControl maxW="200px">
+          <FormLabel>Filter Status</FormLabel>
+          <Select value={filter} onChange={(e) => setFilter(e.target.value)}>
+            <option value="">All</option>
+            <option value="active">Active</option>
+            <option value="inactive">Inactive</option>
+            <option value="draft">Draft</option>
+          </Select>
+        </FormControl>
+      </HStack>
+
+      {loading ? (
+        <Spinner />
+      ) : posts.length === 0 ? (
+        <Text>No job posts found</Text>
+      ) : (
+        <Table size="sm">
+          <Thead>
+            <Tr>
+              <Th>Title</Th>
+              <Th>Status</Th>
+              <Th>Type</Th>
+              <Th>Actions</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {posts.map((post) => (
+              <Tr key={post.id}>
+                <Td>{post.title}</Td>
+                <Td>
+                  <Tag colorScheme={post.status === "active" ? "green" : post.status === "draft" ? "yellow" : "red"}>
+                    {post.status}
+                  </Tag>
+                </Td>
+                <Td>{post.jobType}</Td>
+                <Td>
+                  <HStack className={styles.actions}>
+                    <Button size="xs" onClick={() => editPost(post)}>
+                      Edit
+                    </Button>
+                    <Button size="xs" onClick={() => duplicatePost(post)}>
+                      Duplicate
+                    </Button>
+                    <Button size="xs" onClick={() => toggleStatus(post)}>
+                      {post.status === "active" ? "Deactivate" : "Activate"}
+                    </Button>
+                    <Button size="xs" colorScheme="red" onClick={() => removePost(post)}>
+                      Delete
+                    </Button>
+                  </HStack>
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      )}
+    </Box>
+  );
+}
+

--- a/app/api/job-posts/[id]/route.ts
+++ b/app/api/job-posts/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getJobPost, updateJobPost, deleteJobPost } from "@/lib/services/jobPostService";
+
+export async function GET(req: NextRequest, { params }: any) {
+  const id = Number(params.id);
+  const post = await getJobPost(id);
+  if (!post) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(post);
+}
+
+export async function PUT(req: NextRequest, { params }: any) {
+  const session = await getServerSession(authOptions);
+  const employerId = session?.user?.id ? Number(session.user.id) : undefined;
+  const id = Number(params.id);
+  if (!employerId)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const existing = await getJobPost(id);
+  if (!existing || existing.employerId !== employerId)
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const data = await req.json();
+  const post = await updateJobPost(id, data);
+  return NextResponse.json(post);
+}
+
+export async function DELETE(req: NextRequest, { params }: any) {
+  const session = await getServerSession(authOptions);
+  const employerId = session?.user?.id ? Number(session.user.id) : undefined;
+  const id = Number(params.id);
+  if (!employerId)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const existing = await getJobPost(id);
+  if (!existing || existing.employerId !== employerId)
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  await deleteJobPost(id);
+  return NextResponse.json({ success: true });
+}

--- a/app/api/job-posts/route.ts
+++ b/app/api/job-posts/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getJobPosts, createJobPost } from "@/lib/services/jobPostService";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const session = await getServerSession(authOptions);
+  const filters = {
+    status: searchParams.get("status") || undefined,
+    employerId:
+      searchParams.get("mine") === "true" && session?.user?.id
+        ? Number(session.user.id)
+        : searchParams.get("employerId")
+        ? Number(searchParams.get("employerId"))
+        : undefined,
+  };
+  const posts = await getJobPosts(filters);
+  return NextResponse.json(posts);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  const employerId = session?.user?.id ? Number(session.user.id) : undefined;
+  if (!employerId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const body = await req.json();
+  const { title, description, jobType } = body;
+  if (!title || !description || !jobType) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+  }
+  const post = await createJobPost({ ...body, employerId });
+  return NextResponse.json(post, { status: 201 });
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -18,6 +18,7 @@ export default function Sidebar() {
     { href: "/messages", label: "Messages" },
     { href: "/gigs", label: "Browse Gigs" },
     { href: "/gig-management", label: "Manage Gigs" },
+    { href: "/job-posts", label: "Manage Job Posts" },
   ];
 
   return (

--- a/lib/services/jobPostService.ts
+++ b/lib/services/jobPostService.ts
@@ -1,0 +1,49 @@
+import prisma from "@/lib/prisma";
+import type { Prisma } from "@prisma/client";
+
+export interface JobPostFilters {
+  employerId?: number;
+  status?: string;
+}
+
+export async function getJobPosts(filters: JobPostFilters = {}) {
+  const { employerId, status } = filters;
+  return prisma.jobPost.findMany({
+    where: {
+      ...(employerId ? { employerId } : {}),
+      ...(status ? { status } : {}),
+    },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+export interface JobPostData {
+  title: string;
+  description: string;
+  requirements?: string;
+  salaryMin?: number;
+  salaryMax?: number;
+  benefits?: string;
+  jobType: string;
+  location?: string;
+  deadline?: Date;
+  category?: string;
+  status?: string;
+  employerId: number;
+}
+
+export async function createJobPost(data: JobPostData) {
+  return prisma.jobPost.create({ data });
+}
+
+export async function getJobPost(id: number) {
+  return prisma.jobPost.findUnique({ where: { id } });
+}
+
+export async function updateJobPost(id: number, data: Partial<JobPostData>) {
+  return prisma.jobPost.update({ where: { id }, data });
+}
+
+export async function deleteJobPost(id: number) {
+  return prisma.jobPost.delete({ where: { id } });
+}

--- a/prisma/migrations/20250315000006_add_job_posts/migration.sql
+++ b/prisma/migrations/20250315000006_add_job_posts/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "JobPost" (
+    "id" SERIAL PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "requirements" TEXT,
+    "salaryMin" INTEGER,
+    "salaryMax" INTEGER,
+    "benefits" TEXT,
+    "jobType" TEXT NOT NULL,
+    "location" TEXT,
+    "deadline" TIMESTAMP(3),
+    "category" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'draft',
+    "employerId" INTEGER NOT NULL REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
   chatParticipants ChatParticipant[]
   messages         Message[]
   gigs             Gig[]
+  jobPosts        JobPost[]
 }
 
 model Testimonial {
@@ -132,4 +133,23 @@ model Gig {
   seller      User     @relation(fields: [sellerId], references: [id])
   sellerId    Int
   createdAt   DateTime @default(now())
+}
+
+model JobPost {
+  id          Int      @id @default(autoincrement())
+  title       String
+  description String
+  requirements String?
+  salaryMin   Int?
+  salaryMax   Int?
+  benefits    String?
+  jobType     String
+  location    String?
+  deadline    DateTime?
+  category    String?
+  status      String   @default("draft")
+  employer    User     @relation(fields: [employerId], references: [id])
+  employerId  Int
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -88,6 +88,35 @@ async function main() {
       ],
       skipDuplicates: true,
     });
+
+    await prisma.jobPost.createMany({
+      data: [
+        {
+          title: 'Senior Backend Developer',
+          description: 'Build scalable APIs using Node.js and PostgreSQL.',
+          requirements: '5+ years experience, Node.js, PostgreSQL',
+          salaryMin: 90000,
+          salaryMax: 120000,
+          benefits: 'Health, 401k',
+          jobType: 'full-time',
+          location: 'Remote',
+          status: 'active',
+          employerId: admin.id,
+        },
+        {
+          title: 'Part-time Designer',
+          description: 'Create marketing materials and product mockups.',
+          requirements: 'Adobe Suite, portfolio required',
+          salaryMin: 30000,
+          salaryMax: 45000,
+          jobType: 'part-time',
+          location: 'New York, NY',
+          status: 'draft',
+          employerId: admin.id,
+        },
+      ],
+      skipDuplicates: true,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- add job post schema, services and API routes
- create job post creation and management dashboard page
- link job post management in sidebar and main dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx prisma validate` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_689588a41ad08320a1190608ea6dcf5f