### PR TITLE
feat: add gig product page

### DIFF
--- a/app/(dashboard)/gigs/[id]/page.module.css
+++ b/app/(dashboard)/gigs/[id]/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  padding: 1rem;
+}

--- a/app/(dashboard)/gigs/[id]/page.tsx
+++ b/app/(dashboard)/gigs/[id]/page.tsx
@@ -1,0 +1,13 @@
+import GigDetail from "@/components/GigDetail";
+import api from "@/lib/api";
+import { GigDetails } from "@/lib/types/gig";
+import styles from "./page.module.css";
+
+export default async function GigPage({ params }: { params: { id: string } }) {
+  const gig = await api.get<GigDetails>(`/gigs/${params.id}`);
+  return (
+    <div className={styles.container}>
+      <GigDetail gig={gig} />
+    </div>
+  );
+}

--- a/app/(dashboard)/gigs/page.tsx
+++ b/app/(dashboard)/gigs/page.tsx
@@ -18,7 +18,8 @@ import {
   Heading,
 } from "@chakra-ui/react";
 import api from "@/lib/api";
-import GigCard, { Gig } from "@/components/GigCard";
+import GigCard from "@/components/GigCard";
+import { Gig } from "@/lib/types/gig";
 import styles from "./page.module.css";
 
 export default function GigBrowsePage() {

--- a/app/api/gigs/[id]/route.ts
+++ b/app/api/gigs/[id]/route.ts
@@ -1,7 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
-import { getGig, updateGig, deleteGig } from "@/lib/services/gigService";
+import { getGig, updateGig, deleteGig, incrementGigViews } from "@/lib/services/gigService";
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const id = Number(params.id);
+  const gig = await getGig(id);
+  if (!gig) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  await incrementGigViews(id);
+  return NextResponse.json(gig);
+}
 
 export async function PUT(req: NextRequest, { params }: any) {
   const session = await getServerSession(authOptions);

--- a/components/FavoritesContext.tsx
+++ b/components/FavoritesContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, useContext, useState, ReactNode } from "react";
-import { Gig } from "./GigCard";
+import { Gig } from "@/lib/types/gig";
 
 interface FavoritesContextValue {
   favorites: Gig[];

--- a/components/GigCard.module.css
+++ b/components/GigCard.module.css
@@ -1,5 +1,6 @@
 .card {
   transition: box-shadow 0.2s ease;
+  cursor: pointer;
 }
 
 .card:hover {

--- a/components/GigCard.tsx
+++ b/components/GigCard.tsx
@@ -1,21 +1,13 @@
 "use client";
 
+import NextLink from "next/link";
 import { Box, Image, Text, HStack, Icon, VStack, IconButton } from "@chakra-ui/react";
 import { StarIcon } from "@chakra-ui/icons";
 import { FaHeart } from "react-icons/fa";
 import styles from "./GigCard.module.css";
 import { formatCurrency } from "@/lib/utils/format";
 import { useFavorites } from "@/components/FavoritesContext";
-
-export interface Gig {
-  id: number;
-  title: string;
-  price: number;
-  category?: string | null;
-  thumbnail?: string | null;
-  rating?: number | null;
-  seller: { name: string | null };
-}
+import { Gig } from "@/lib/types/gig";
 
 export default function GigCard({ gig }: { gig: Gig }) {
   const { toggleFavorite, isFavorite } = useFavorites();
@@ -29,6 +21,8 @@ export default function GigCard({ gig }: { gig: Gig }) {
 
   return (
     <Box
+      as={NextLink}
+      href={`/gigs/${gig.id}`}
       borderWidth="1px"
       borderRadius="md"
       overflow="hidden"
@@ -44,7 +38,10 @@ export default function GigCard({ gig }: { gig: Gig }) {
         right={2}
         variant="ghost"
         color={isFavorite(gig.id) ? "red.500" : "gray.300"}
-        onClick={() => toggleFavorite(gig)}
+        onClick={(e) => {
+          e.preventDefault();
+          toggleFavorite(gig);
+        }}
       />
       {gig.thumbnail && (
         <Image

--- a/components/GigDetail.module.css
+++ b/components/GigDetail.module.css
@@ -1,0 +1,4 @@
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+}

--- a/components/GigDetail.tsx
+++ b/components/GigDetail.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import NextLink from "next/link";
+import {
+  Box,
+  Image,
+  Heading,
+  Text,
+  VStack,
+  HStack,
+  Button,
+  Avatar,
+  Divider,
+} from "@chakra-ui/react";
+import { GigDetails } from "@/lib/types/gig";
+import { formatCurrency } from "@/lib/utils/format";
+import styles from "./GigDetail.module.css";
+
+export default function GigDetail({ gig }: { gig: GigDetails }) {
+  return (
+    <Box
+      className={styles.container}
+      bg="white"
+      borderWidth="1px"
+      borderRadius="md"
+      overflow="hidden"
+    >
+      {gig.thumbnail && (
+        <Image src={gig.thumbnail} alt={gig.title} w="100%" h="300px" objectFit="cover" />
+      )}
+      <VStack align="start" p={6} spacing={4}>
+        <Heading size="lg">{gig.title}</Heading>
+        <HStack spacing={3}>
+          <Avatar name={gig.seller.name || "Seller"} src={gig.seller.image || undefined} size="sm" />
+          <Text fontWeight="medium">{gig.seller.name}</Text>
+        </HStack>
+        <Text fontSize="xl" color="brand.500" fontWeight="bold">
+          {formatCurrency(gig.price)}
+        </Text>
+        <Text>{gig.description}</Text>
+        <Divider />
+        <HStack spacing={4}>
+          <Button as={NextLink} href={`/checkout?gigId=${gig.id}`} colorScheme="brand">
+            Order Now
+          </Button>
+          <Button
+            as={NextLink}
+            href={`/messages?recipient=${gig.seller.id}`}
+            variant="outline"
+            colorScheme="brand"
+          >
+            Contact Seller
+          </Button>
+        </HStack>
+      </VStack>
+    </Box>
+  );
+}

--- a/lib/services/gigService.ts
+++ b/lib/services/gigService.ts
@@ -53,15 +53,29 @@ export async function createGig(data: CreateGigData) {
 }
 
 export async function getGig(id: number) {
-  return prisma.gig.findUnique({ where: { id } });
+  return prisma.gig.findUnique({
+    where: { id },
+    include: {
+      seller: {
+        select: { id: true, name: true, image: true },
+      },
+    },
+  });
 }
 
-export async function updateGig(id: number, data: Partial<CreateGigData> & { status?: string }) {
+export async function updateGig(
+  id: number,
+  data: Partial<CreateGigData> & { status?: string }
+) {
   return prisma.gig.update({ where: { id }, data });
 }
 
 export async function deleteGig(id: number) {
   return prisma.gig.delete({ where: { id } });
+}
+
+export async function incrementGigViews(id: number) {
+  return prisma.gig.update({ where: { id }, data: { views: { increment: 1 } } });
 }
 
 export async function getSellerGigs(sellerId: number) {

--- a/lib/types/gig.ts
+++ b/lib/types/gig.ts
@@ -1,0 +1,20 @@
+export interface SellerInfo {
+  id: number;
+  name: string | null;
+  image: string | null;
+}
+
+export interface Gig {
+  id: number;
+  title: string;
+  price: number;
+  category?: string | null;
+  thumbnail?: string | null;
+  rating?: number | null;
+  seller: SellerInfo;
+}
+
+export interface GigDetails extends Gig {
+  description: string;
+  views: number;
+}


### PR DESCRIPTION
## Summary
- build buyer-facing gig product page with Chakra UI
- add GET gig endpoint with view tracking
- share gig types across components and link cards to detail view

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689588e479148320ae68c71c59112712