### PR TITLE
feat: add service management pages

### DIFF
--- a/app/(dashboard)/service-management/page.module.css
+++ b/app/(dashboard)/service-management/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  padding: 1rem;
+}

--- a/app/(dashboard)/service-management/page.tsx
+++ b/app/(dashboard)/service-management/page.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Heading,
+  SimpleGrid,
+  VStack,
+  FormControl,
+  FormLabel,
+  Input,
+  NumberInput,
+  NumberInputField,
+  Button,
+  Select,
+  HStack,
+  Text,
+  Spinner,
+} from "@chakra-ui/react";
+import api from "@/lib/api";
+import { Service, ServiceOrder } from "@/lib/types/service";
+import styles from "./page.module.css";
+
+export default function ServiceManagementPage() {
+  const [services, setServices] = useState<Service[]>([]);
+  const [orders, setOrders] = useState<ServiceOrder[]>([]);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [price, setPrice] = useState<string | number>("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const load = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const [svc, ord] = await Promise.all([
+        api.get<Service[]>("/services?mine=true"),
+        api.get<ServiceOrder[]>("/service-orders?sellerId=mine"),
+      ]);
+      setServices(svc);
+      setOrders(ord);
+    } catch (err: any) {
+      setError(err.message || "Failed to load data");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const create = async () => {
+    try {
+      await api.post<Service>("/services", {
+        title,
+        description,
+        price: Number(price),
+      });
+      setTitle("");
+      setDescription("");
+      setPrice("");
+      await load();
+    } catch (err: any) {
+      setError(err.message || "Failed to create service");
+    }
+  };
+
+  const updateStatus = async (id: number, status: string) => {
+    try {
+      await api.put<Service>(`/services/${id}`, { status });
+      setServices((prev) =>
+        prev.map((s) => (s.id === id ? { ...s, status } : s))
+      );
+    } catch (err: any) {
+      setError(err.message || "Failed to update service");
+    }
+  };
+
+  if (loading) return <Spinner />;
+
+  return (
+    <Box className={styles.container}>
+      <Heading size="lg" mb={6}>
+        Service & Order Management
+      </Heading>
+      {error && (
+        <Text color="red.500" mb={4}>
+          {error}
+        </Text>
+      )}
+      <Heading size="md" mb={4}>
+        Create Service
+      </Heading>
+      <SimpleGrid
+        as="form"
+        columns={{ base: 1, md: 3 }}
+        spacing={4}
+        mb={8}
+        onSubmit={(e) => {
+          e.preventDefault();
+          create();
+        }}
+      >
+        <FormControl isRequired>
+          <FormLabel>Title</FormLabel>
+          <Input value={title} onChange={(e) => setTitle(e.target.value)} />
+        </FormControl>
+        <FormControl isRequired>
+          <FormLabel>Description</FormLabel>
+          <Input
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </FormControl>
+        <FormControl isRequired>
+          <FormLabel>Price</FormLabel>
+          <NumberInput min={0} value={price} onChange={(v) => setPrice(v)}>
+            <NumberInputField />
+          </NumberInput>
+        </FormControl>
+        <Button type="submit" colorScheme="brand" alignSelf="end">
+          Create
+        </Button>
+      </SimpleGrid>
+
+      <Heading size="md" mb={4}>
+        Your Services
+      </Heading>
+      <VStack align="stretch" spacing={3} mb={10}>
+        {services.map((service) => (
+          <HStack
+            key={service.id}
+            borderWidth="1px"
+            borderRadius="md"
+            p={3}
+            bg="white"
+            justify="space-between"
+          >
+            <Text>{service.title}</Text>
+            <Select
+              value={service.status}
+              onChange={(e) => updateStatus(service.id, e.target.value)}
+              maxW="150px"
+            >
+              <option value="active">active</option>
+              <option value="paused">paused</option>
+              <option value="inactive">inactive</option>
+            </Select>
+          </HStack>
+        ))}
+      </VStack>
+
+      <Heading size="md" mb={4}>
+        Orders
+      </Heading>
+      <VStack align="stretch" spacing={3}>
+        {orders.map((order) => (
+          <Box
+            key={order.id}
+            borderWidth="1px"
+            borderRadius="md"
+            p={3}
+            bg="white"
+          >
+            <HStack justify="space-between">
+              <Text>
+                {order.service.title} - {order.buyer.name}
+              </Text>
+              <Text>{order.status}</Text>
+            </HStack>
+          </Box>
+        ))}
+      </VStack>
+    </Box>
+  );
+}

--- a/app/(dashboard)/services/page.module.css
+++ b/app/(dashboard)/services/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  padding: 1rem;
+}

--- a/app/(dashboard)/services/page.tsx
+++ b/app/(dashboard)/services/page.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Heading,
+  Text,
+  SimpleGrid,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+  Stat,
+  StatLabel,
+  StatNumber,
+  HStack,
+  VStack,
+  Spinner,
+} from "@chakra-ui/react";
+import api from "@/lib/api";
+import { Service, ServiceOrder } from "@/lib/types/service";
+import ServiceCard from "@/components/ServiceCard";
+import styles from "./page.module.css";
+
+export default function ServicesOverviewPage() {
+  const [services, setServices] = useState<Service[]>([]);
+  const [sellerOrders, setSellerOrders] = useState<ServiceOrder[]>([]);
+  const [buyerOrders, setBuyerOrders] = useState<ServiceOrder[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [svc, sOrders, bOrders] = await Promise.all([
+          api.get<Service[]>("/services?mine=true"),
+          api.get<ServiceOrder[]>("/service-orders?sellerId=mine"),
+          api.get<ServiceOrder[]>("/service-orders?mine=true"),
+        ]);
+        setServices(svc);
+        setSellerOrders(sOrders);
+        setBuyerOrders(bOrders);
+      } catch (err: any) {
+        setError(err.message || "Failed to load data");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const activeServices = services.filter((s) => s.status === "active").length;
+  const pendingOrders = sellerOrders.filter((o) => o.status === "pending").length;
+  const totalEarnings = sellerOrders
+    .filter((o) => o.status === "completed")
+    .reduce((sum, o) => sum + o.service.price, 0);
+
+  const upcomingBookings = buyerOrders.filter((o) => o.status === "pending").length;
+  const totalSpend = buyerOrders
+    .filter((o) => o.status === "completed")
+    .reduce((sum, o) => sum + o.service.price, 0);
+
+  if (loading) return <Spinner />;
+
+  return (
+    <Box className={styles.container}>
+      <Heading size="lg" mb={6}>
+        Local Services Overview
+      </Heading>
+      {error && (
+        <Text color="red.500" mb={4}>
+          {error}
+        </Text>
+      )}
+      <Tabs variant="enclosed" colorScheme="brand">
+        <TabList>
+          <Tab>Seller</Tab>
+          <Tab>Buyer</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4} mb={6}>
+              <Stat>
+                <StatLabel>Active Services</StatLabel>
+                <StatNumber>{activeServices}</StatNumber>
+              </Stat>
+              <Stat>
+                <StatLabel>Pending Orders</StatLabel>
+                <StatNumber>{pendingOrders}</StatNumber>
+              </Stat>
+              <Stat>
+                <StatLabel>Total Earnings</StatLabel>
+                <StatNumber>${totalEarnings.toFixed(2)}</StatNumber>
+              </Stat>
+            </SimpleGrid>
+            <Heading size="md" mb={4}>
+              Your Services
+            </Heading>
+            <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={4}>
+              {services.map((service) => (
+                <ServiceCard key={service.id} service={service} />
+              ))}
+            </SimpleGrid>
+          </TabPanel>
+          <TabPanel>
+            <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4} mb={6}>
+              <Stat>
+                <StatLabel>Upcoming Bookings</StatLabel>
+                <StatNumber>{upcomingBookings}</StatNumber>
+              </Stat>
+              <Stat>
+                <StatLabel>Total Spend</StatLabel>
+                <StatNumber>${totalSpend.toFixed(2)}</StatNumber>
+              </Stat>
+              <Stat>
+                <StatLabel>Orders</StatLabel>
+                <StatNumber>{buyerOrders.length}</StatNumber>
+              </Stat>
+            </SimpleGrid>
+            <Heading size="md" mb={4}>
+              Active Orders
+            </Heading>
+            <VStack align="stretch" spacing={3}>
+              {buyerOrders.map((order) => (
+                <Box
+                  key={order.id}
+                  borderWidth="1px"
+                  borderRadius="md"
+                  p={3}
+                  bg="white"
+                >
+                  <HStack justify="space-between">
+                    <Text>{order.service.title}</Text>
+                    <Text>{order.status}</Text>
+                  </HStack>
+                </Box>
+              ))}
+            </VStack>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </Box>
+  );
+}

--- a/app/api/service-orders/route.ts
+++ b/app/api/service-orders/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import {
+  getServiceOrders,
+  createServiceOrder,
+} from "@/lib/services/serviceProviderService";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const session = await getServerSession(authOptions);
+  const filters = {
+    sellerId:
+      searchParams.get("sellerId") === "mine" && session?.user?.id
+        ? Number(session.user.id)
+        : searchParams.get("sellerId")
+        ? Number(searchParams.get("sellerId"))
+        : undefined,
+    buyerId:
+      searchParams.get("mine") === "true" && session?.user?.id
+        ? Number(session.user.id)
+        : searchParams.get("buyerId")
+        ? Number(searchParams.get("buyerId"))
+        : undefined,
+    status: searchParams.get("status") || undefined,
+  };
+  const orders = await getServiceOrders(filters);
+  return NextResponse.json(orders);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  const buyerId = session?.user?.id ? Number(session.user.id) : undefined;
+  if (!buyerId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { serviceId, scheduledFor } = await req.json();
+  if (!serviceId) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+  }
+  const order = await createServiceOrder({
+    serviceId,
+    buyerId,
+    scheduledFor: scheduledFor ? new Date(scheduledFor) : null,
+  });
+  return NextResponse.json(order, { status: 201 });
+}

--- a/app/api/services/[id]/route.ts
+++ b/app/api/services/[id]/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import {
+  getService,
+  updateService,
+  deleteService,
+} from "@/lib/services/serviceProviderService";
+
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const service = await getService(Number(params.id));
+  return NextResponse.json(service);
+}
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const data = await req.json();
+  const service = await updateService(Number(params.id), data);
+  return NextResponse.json(service);
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  await deleteService(Number(params.id));
+  return NextResponse.json({ success: true });
+}

--- a/app/api/services/route.ts
+++ b/app/api/services/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import {
+  getServices,
+  createService,
+} from "@/lib/services/serviceProviderService";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const session = await getServerSession(authOptions);
+  const filters = {
+    search: searchParams.get("search") || undefined,
+    status: searchParams.get("status") || undefined,
+    sellerId:
+      searchParams.get("mine") === "true" && session?.user?.id
+        ? Number(session.user.id)
+        : undefined,
+  };
+  const services = await getServices(filters);
+  return NextResponse.json(services);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  const sellerId = session?.user?.id ? Number(session.user.id) : undefined;
+  if (!sellerId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { title, description, price, status } = await req.json();
+  if (!title || !description || typeof price !== "number") {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+  }
+  const service = await createService({
+    title,
+    description,
+    price,
+    sellerId,
+    status,
+  });
+  return NextResponse.json(service, { status: 201 });
+}

--- a/components/ServiceCard.module.css
+++ b/components/ServiceCard.module.css
@@ -1,0 +1,7 @@
+.card {
+  transition: box-shadow 0.2s ease;
+}
+
+.card:hover {
+  box-shadow: 0 0 0 1px var(--chakra-colors-brand-500);
+}

--- a/components/ServiceCard.tsx
+++ b/components/ServiceCard.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import NextLink from "next/link";
+import { Box, Text, VStack, HStack, Button } from "@chakra-ui/react";
+import styles from "./ServiceCard.module.css";
+import { Service } from "@/lib/types/service";
+import { formatCurrency } from "@/lib/utils/format";
+
+export default function ServiceCard({ service }: { service: Service }) {
+  return (
+    <Box
+      borderWidth="1px"
+      borderRadius="md"
+      p={4}
+      bg="white"
+      className={styles.card}
+    >
+      <VStack align="start" spacing={2}>
+        <Text fontWeight="bold" fontSize="lg">
+          {service.title}
+        </Text>
+        <Text fontSize="sm" color="gray.600">
+          {service.description}
+        </Text>
+        <HStack justify="space-between" w="full">
+          <Text color="brand.500" fontWeight="bold">
+            {formatCurrency(service.price)}
+          </Text>
+          <Button
+            as={NextLink}
+            href={`/services/${service.id}`}
+            size="sm"
+            colorScheme="brand"
+          >
+            Details
+          </Button>
+        </HStack>
+      </VStack>
+    </Box>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -20,6 +20,8 @@ export default function Sidebar() {
     { href: "/applications", label: "Applications" },
     { href: "/gigs", label: "Browse Gigs" },
     { href: "/gig-management", label: "Manage Gigs" },
+    { href: "/services", label: "Services" },
+    { href: "/service-management", label: "Manage Services" },
   ];
 
   return (

--- a/lib/services/serviceProviderService.ts
+++ b/lib/services/serviceProviderService.ts
@@ -1,0 +1,87 @@
+import prisma from "@/lib/prisma";
+import type { Prisma } from "@prisma/client";
+
+export interface ServiceFilters {
+  search?: string;
+  status?: string;
+  sellerId?: number;
+}
+
+export async function getServices(filters: ServiceFilters = {}) {
+  const { search, status, sellerId } = filters;
+  return prisma.service.findMany({
+    where: {
+      ...(search ? { title: { contains: search, mode: "insensitive" } } : {}),
+      ...(status ? { status } : {}),
+      ...(sellerId ? { sellerId } : {}),
+    },
+    include: {
+      seller: { select: { id: true, name: true, image: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+export interface CreateServiceData {
+  title: string;
+  description: string;
+  price: number;
+  sellerId: number;
+  status?: string;
+}
+
+export async function createService(data: CreateServiceData) {
+  return prisma.service.create({ data });
+}
+
+export async function getService(id: number) {
+  return prisma.service.findUnique({
+    where: { id },
+    include: { seller: { select: { id: true, name: true, image: true } } },
+  });
+}
+
+export async function updateService(
+  id: number,
+  data: Partial<CreateServiceData> & { status?: string }
+) {
+  return prisma.service.update({ where: { id }, data });
+}
+
+export async function deleteService(id: number) {
+  return prisma.service.delete({ where: { id } });
+}
+
+export interface ServiceOrderFilters {
+  sellerId?: number;
+  buyerId?: number;
+  status?: string;
+}
+
+export async function getServiceOrders(filters: ServiceOrderFilters = {}) {
+  const { sellerId, buyerId, status } = filters;
+  return prisma.serviceOrder.findMany({
+    where: {
+      ...(sellerId ? { service: { sellerId } } : {}),
+      ...(buyerId ? { buyerId } : {}),
+      ...(status ? { status } : {}),
+    },
+    include: {
+      service: {
+        include: { seller: { select: { id: true, name: true, image: true } } },
+      },
+      buyer: { select: { id: true, name: true, image: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+export interface CreateServiceOrderData {
+  serviceId: number;
+  buyerId: number;
+  scheduledFor?: Date | null;
+}
+
+export async function createServiceOrder(data: CreateServiceOrderData) {
+  return prisma.serviceOrder.create({ data });
+}

--- a/lib/types/service.ts
+++ b/lib/types/service.ts
@@ -1,0 +1,26 @@
+export interface Service {
+  id: number;
+  title: string;
+  description: string;
+  price: number;
+  status: string;
+  seller: {
+    id: number;
+    name: string | null;
+    image?: string | null;
+  };
+  createdAt: string;
+}
+
+export interface ServiceOrder {
+  id: number;
+  service: Service;
+  buyer: {
+    id: number;
+    name: string | null;
+    image?: string | null;
+  };
+  status: string;
+  scheduledFor?: string | null;
+  createdAt: string;
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -156,6 +156,29 @@ model Gig {
   createdAt   DateTime @default(now())
 }
 
+model Service {
+  id          Int      @id @default(autoincrement())
+  title       String
+  description String
+  price       Int
+  status      String   @default("active")
+  seller      User     @relation(fields: [sellerId], references: [id])
+  sellerId    Int
+  orders      ServiceOrder[]
+  createdAt   DateTime @default(now())
+}
+
+model ServiceOrder {
+  id          Int      @id @default(autoincrement())
+  service     Service  @relation(fields: [serviceId], references: [id])
+  serviceId   Int
+  buyer       User     @relation(fields: [buyerId], references: [id])
+  buyerId     Int
+  status      String   @default("pending")
+  scheduledFor DateTime?
+  createdAt   DateTime @default(now())
+}
+
 model Job {
   id        Int      @id @default(autoincrement())
   title     String


### PR DESCRIPTION
## Summary
- add prisma models and service layer for services and orders
- expose REST endpoints for services and service orders
- build services overview and management pages with Chakra UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68958ce51e0883208bb47b760de6d144