### PR TITLE
Add service creation, editing, and search pages

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -60,6 +60,12 @@ export default function DashboardPage() {
         <Button as={Link} href="/gig-management" colorScheme="brand" variant="outline">
           Manage Gigs
         </Button>
+        <Button as={Link} href="/services" colorScheme="brand" variant="outline">
+          Browse Services
+        </Button>
+        <Button as={Link} href="/services/create" colorScheme="brand" variant="outline">
+          Create Service
+        </Button>
         <Button as={Link} href="/messages" colorScheme="brand" variant="outline">
           Messages
         </Button>

--- a/app/(dashboard)/services/[id]/edit/page.module.css
+++ b/app/(dashboard)/services/[id]/edit/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  padding: 1rem;
+}

--- a/app/(dashboard)/services/[id]/edit/page.tsx
+++ b/app/(dashboard)/services/[id]/edit/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, useParams } from "next/navigation";
+import { Box, useToast } from "@chakra-ui/react";
+import api from "@/lib/api";
+import ServiceForm, { ServiceFormData } from "@/components/ServiceForm";
+import styles from "./page.module.css";
+
+export default function EditServicePage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const toast = useToast();
+  const [initial, setInitial] = useState<ServiceFormData | null>(null);
+
+  useEffect(() => {
+    api
+      .get<ServiceFormData>(`/services/${params.id}`)
+      .then(setInitial)
+      .catch(() => toast({ status: "error", description: "Failed to load" }));
+  }, [params.id, toast]);
+
+  const handleSubmit = async (data: ServiceFormData) => {
+    try {
+      await api.put(`/services/${params.id}`, data);
+      toast({ status: "success", description: "Service updated" });
+      router.push(`/services/${params.id}`);
+    } catch (e: any) {
+      toast({ status: "error", description: e.message });
+    }
+  };
+
+  if (!initial) return null;
+
+  return (
+    <Box className={styles.container}>
+      <ServiceForm initialData={initial} onSubmit={handleSubmit} submitLabel="Update" />
+    </Box>
+  );
+}

--- a/app/(dashboard)/services/[id]/page.module.css
+++ b/app/(dashboard)/services/[id]/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  padding: 1rem;
+}

--- a/app/(dashboard)/services/[id]/page.tsx
+++ b/app/(dashboard)/services/[id]/page.tsx
@@ -1,0 +1,41 @@
+import { notFound } from "next/navigation";
+import { Box, Heading, Text, Stack, Button } from "@chakra-ui/react";
+import Link from "next/link";
+import api from "@/lib/api";
+import styles from "./page.module.css";
+
+interface Service {
+  id: number;
+  title: string;
+  description: string;
+  price: number;
+  location?: string | null;
+  seller: { id: number; name: string | null };
+}
+
+async function fetchService(id: string): Promise<Service | null> {
+  try {
+    return await api.get<Service>(`/services/${id}`);
+  } catch {
+    return null;
+  }
+}
+
+export default async function ServiceDetails({ params }: { params: { id: string } }) {
+  const service = await fetchService(params.id);
+  if (!service) return notFound();
+  return (
+    <Box className={styles.container}>
+      <Stack spacing={4}>
+        <Heading>{service.title}</Heading>
+        <Text>{service.description}</Text>
+        <Text fontWeight="bold">${service.price}</Text>
+        {service.location && <Text>Location: {service.location}</Text>}
+        <Text>Seller: {service.seller.name || `User ${service.seller.id}`}</Text>
+        <Button as={Link} href={`/services/${service.id}/edit`} colorScheme="brand" variant="outline">
+          Edit Service
+        </Button>
+      </Stack>
+    </Box>
+  );
+}

--- a/app/(dashboard)/services/create/page.module.css
+++ b/app/(dashboard)/services/create/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  padding: 1rem;
+}

--- a/app/(dashboard)/services/create/page.tsx
+++ b/app/(dashboard)/services/create/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Box, useToast } from "@chakra-ui/react";
+import api from "@/lib/api";
+import ServiceForm, { ServiceFormData } from "@/components/ServiceForm";
+import styles from "./page.module.css";
+
+interface Service { id: number }
+
+export default function CreateServicePage() {
+  const router = useRouter();
+  const toast = useToast();
+
+  const handleSubmit = async (data: ServiceFormData) => {
+    try {
+      const service = await api.post<Service>(`/services`, data);
+      toast({ status: "success", description: "Service created" });
+      router.push(`/services/${service.id}`);
+    } catch (e: any) {
+      toast({ status: "error", description: e.message });
+    }
+  };
+
+  return (
+    <Box className={styles.container}>
+      <ServiceForm onSubmit={handleSubmit} submitLabel="Create" />
+    </Box>
+  );
+}

--- a/app/(dashboard)/services/page.module.css
+++ b/app/(dashboard)/services/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  padding: 1rem;
+}

--- a/app/(dashboard)/services/page.tsx
+++ b/app/(dashboard)/services/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  SimpleGrid,
+  Text,
+  VStack,
+  HStack,
+  Card,
+  CardBody,
+  Heading,
+} from "@chakra-ui/react";
+import Link from "next/link";
+import api from "@/lib/api";
+import styles from "./page.module.css";
+
+interface Service {
+  id: number;
+  title: string;
+  description: string;
+  price: number;
+  location?: string | null;
+}
+
+export default function ServiceSearchPage() {
+  const [search, setSearch] = useState("");
+  const [location, setLocation] = useState("");
+  const [results, setResults] = useState<Service[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const performSearch = async () => {
+    setLoading(true);
+    const params = new URLSearchParams();
+    if (search) params.set("search", search);
+    if (location) params.set("location", location);
+    const data = await api.get<Service[]>(`/services?${params.toString()}`);
+    setResults(data);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    performSearch();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <Box className={styles.container}>
+      <VStack as="form" spacing={4} align="stretch" onSubmit={(e) => e.preventDefault()}>
+        <HStack spacing={4} flexWrap="wrap">
+          <FormControl maxW="300px">
+            <FormLabel>Search</FormLabel>
+            <Input value={search} onChange={(e) => setSearch(e.target.value)} />
+          </FormControl>
+          <FormControl maxW="200px">
+            <FormLabel>Location</FormLabel>
+            <Input value={location} onChange={(e) => setLocation(e.target.value)} />
+          </FormControl>
+          <Button colorScheme="brand" onClick={performSearch} isLoading={loading} alignSelf="flex-end">
+            Search
+          </Button>
+        </HStack>
+      </VStack>
+      <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4} mt={6}>
+        {results.map((service) => (
+          <Card key={service.id} as={Link} href={`/services/${service.id}`}> 
+            <CardBody>
+              <Heading size="md">{service.title}</Heading>
+              <Text>${service.price}</Text>
+              {service.location && <Text fontSize="sm">{service.location}</Text>}
+            </CardBody>
+          </Card>
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}

--- a/app/api/services/[id]/route.ts
+++ b/app/api/services/[id]/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import {
+  getService,
+  updateService,
+  deleteService,
+} from "@/lib/services/serviceService";
+
+interface Params {
+  params: { id: string };
+}
+
+export async function GET(_req: Request, { params }: Params) {
+  const id = Number(params.id);
+  const service = await getService(id);
+  if (!service) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(service);
+}
+
+export async function PUT(req: Request, { params }: Params) {
+  const session = await getServerSession(authOptions);
+  const id = Number(params.id);
+  const existing = await getService(id);
+  if (!existing) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  if (existing.sellerId !== Number(session?.user?.id)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const data = await req.json();
+  const service = await updateService(id, data);
+  return NextResponse.json(service);
+}
+
+export async function DELETE(_req: Request, { params }: Params) {
+  const session = await getServerSession(authOptions);
+  const id = Number(params.id);
+  const existing = await getService(id);
+  if (!existing) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  if (existing.sellerId !== Number(session?.user?.id)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  await deleteService(id);
+  return NextResponse.json({ success: true });
+}

--- a/app/api/services/route.ts
+++ b/app/api/services/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import {
+  getServices,
+  createService,
+} from "@/lib/services/serviceService";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const session = await getServerSession(authOptions);
+  const filters = {
+    search: searchParams.get("search") || undefined,
+    category: searchParams.get("category") || undefined,
+    location: searchParams.get("location") || undefined,
+    minPrice: searchParams.get("minPrice")
+      ? Number(searchParams.get("minPrice"))
+      : undefined,
+    maxPrice: searchParams.get("maxPrice")
+      ? Number(searchParams.get("maxPrice"))
+      : undefined,
+    sellerId:
+      searchParams.get("mine") === "true" && session?.user?.id
+        ? Number(session.user.id)
+        : searchParams.get("sellerId")
+        ? Number(searchParams.get("sellerId"))
+        : undefined,
+    status: searchParams.get("status") || undefined,
+  } as const;
+  const services = await getServices(filters);
+  return NextResponse.json(services);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  const sellerId = session?.user?.id ? Number(session.user.id) : undefined;
+  if (!sellerId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { title, description, price, category, location, status } = await req.json();
+  if (!title || !description || typeof price !== "number") {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+  }
+  const service = await createService({
+    title,
+    description,
+    price,
+    category,
+    location,
+    sellerId,
+    status,
+  });
+  return NextResponse.json(service, { status: 201 });
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -73,6 +73,9 @@ export default function Navbar() {
             <MenuItem as={Link} href="/billing">
               Billing
             </MenuItem>
+            <MenuItem as={Link} href="/services">
+              Services
+            </MenuItem>
             <MenuItem onClick={() => signOut()}>Logout</MenuItem>
           </MenuList>
         </Menu>

--- a/components/ServiceForm.module.css
+++ b/components/ServiceForm.module.css
@@ -1,0 +1,5 @@
+.form {
+  background: white;
+  padding: 1rem;
+  border-radius: 0.5rem;
+}

--- a/components/ServiceForm.tsx
+++ b/components/ServiceForm.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  NumberInput,
+  NumberInputField,
+  VStack,
+} from "@chakra-ui/react";
+import styles from "./ServiceForm.module.css";
+
+export interface ServiceFormData {
+  title: string;
+  description: string;
+  price: number;
+  category?: string;
+  location?: string;
+}
+
+interface Props {
+  initialData?: ServiceFormData;
+  onSubmit: (data: ServiceFormData) => Promise<void>;
+  submitLabel?: string;
+}
+
+export default function ServiceForm({
+  initialData,
+  onSubmit,
+  submitLabel = "Submit",
+}: Props) {
+  const [data, setData] = useState<ServiceFormData>(
+    initialData || {
+      title: "",
+      description: "",
+      price: 0,
+      category: "",
+      location: "",
+    }
+  );
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handlePriceChange = (_: string, valueAsNumber: number) => {
+    setData((prev) => ({ ...prev, price: valueAsNumber }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    await onSubmit(data);
+    setLoading(false);
+  };
+
+  return (
+    <Box as="form" onSubmit={handleSubmit} className={styles.form}>
+      <VStack spacing={4} align="stretch">
+        <FormControl isRequired>
+          <FormLabel>Title</FormLabel>
+          <Input name="title" value={data.title} onChange={handleChange} />
+        </FormControl>
+        <FormControl isRequired>
+          <FormLabel>Description</FormLabel>
+          <Textarea
+            name="description"
+            value={data.description}
+            onChange={handleChange}
+          />
+        </FormControl>
+        <FormControl isRequired>
+          <FormLabel>Price</FormLabel>
+          <NumberInput
+            value={data.price}
+            onChange={handlePriceChange}
+            min={0}
+          >
+            <NumberInputField name="price" />
+          </NumberInput>
+        </FormControl>
+        <FormControl>
+          <FormLabel>Category</FormLabel>
+          <Input name="category" value={data.category} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Location</FormLabel>
+          <Input name="location" value={data.location} onChange={handleChange} />
+        </FormControl>
+        <Button type="submit" colorScheme="brand" isLoading={loading}>
+          {submitLabel}
+        </Button>
+      </VStack>
+    </Box>
+  );
+}

--- a/lib/services/serviceService.ts
+++ b/lib/services/serviceService.ts
@@ -1,0 +1,72 @@
+import prisma from "@/lib/prisma";
+import type { Prisma } from "@prisma/client";
+
+export interface ServiceFilters {
+  search?: string;
+  category?: string;
+  minPrice?: number;
+  maxPrice?: number;
+  location?: string;
+  sellerId?: number;
+  status?: string;
+}
+
+export async function getServices(filters: ServiceFilters = {}) {
+  const { search, category, minPrice, maxPrice, location, sellerId, status } = filters;
+  const orderBy: Prisma.ServiceOrderByWithRelationInput = { createdAt: "desc" };
+
+  return prisma.service.findMany({
+    where: {
+      ...(search ? { title: { contains: search, mode: "insensitive" } } : {}),
+      ...(category ? { category } : {}),
+      ...(status ? { status } : {}),
+      ...(sellerId ? { sellerId } : {}),
+      ...(location ? { location: { contains: location, mode: "insensitive" } } : {}),
+      ...(minPrice || maxPrice
+        ? { price: { gte: minPrice || 0, lte: maxPrice || undefined } }
+        : {}),
+    },
+    include: {
+      seller: {
+        select: { id: true, name: true, image: true },
+      },
+    },
+    orderBy,
+  });
+}
+
+export interface CreateServiceData {
+  title: string;
+  description: string;
+  price: number;
+  category?: string;
+  location?: string;
+  sellerId: number;
+  status?: string;
+}
+
+export async function createService(data: CreateServiceData) {
+  return prisma.service.create({ data });
+}
+
+export async function getService(id: number) {
+  return prisma.service.findUnique({
+    where: { id },
+    include: {
+      seller: {
+        select: { id: true, name: true, image: true },
+      },
+    },
+  });
+}
+
+export async function updateService(
+  id: number,
+  data: Partial<CreateServiceData> & { status?: string }
+) {
+  return prisma.service.update({ where: { id }, data });
+}
+
+export async function deleteService(id: number) {
+  return prisma.service.delete({ where: { id } });
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model User {
   chatParticipants ChatParticipant[]
   messages         Message[]
   gigs             Gig[]
+  services         Service[]
 }
 
 model Testimonial {
@@ -151,6 +152,19 @@ model Gig {
   rating      Float?
   status      String   @default("active")
   views       Int      @default(0)
+  seller      User     @relation(fields: [sellerId], references: [id])
+  sellerId    Int
+  createdAt   DateTime @default(now())
+}
+
+model Service {
+  id          Int      @id @default(autoincrement())
+  title       String
+  description String
+  price       Int
+  category    String?
+  location    String?
+  status      String   @default("active")
   seller      User     @relation(fields: [sellerId], references: [id])
   sellerId    Int
   createdAt   DateTime @default(now())


### PR DESCRIPTION
## Summary
- extend Prisma schema with Service model and user relation
- add service CRUD utilities and API routes
- build Chakra-based pages and forms for creating, editing, searching, and viewing services
- expose service navigation links in dashboard and navbar

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*
- `npx prisma migrate dev --name add_service --create-only` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68958cf208c48320b3c1cab0c5e4e86f