### PR TITLE
Add opportunity and networking dashboards

### DIFF
--- a/app/(dashboard)/networking/page.module.css
+++ b/app/(dashboard)/networking/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  display: block;
+}

--- a/app/(dashboard)/networking/page.tsx
+++ b/app/(dashboard)/networking/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Heading,
+  SimpleGrid,
+  Text,
+} from "@chakra-ui/react";
+import api from "@/lib/api";
+import styles from "./page.module.css";
+
+interface Session {
+  id: number;
+  title: string;
+  description: string | null;
+  date: string;
+}
+
+export default function NetworkingDashboard() {
+  const [sessions, setSessions] = useState<Session[]>([]);
+
+  useEffect(() => {
+    api
+      .get<Session[]>("/networking")
+      .then(setSessions)
+      .catch(console.error);
+  }, []);
+
+  return (
+    <Box className={styles.container}>
+      <Heading size="lg" mb={4}>
+        Networking Dashboard
+      </Heading>
+      <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
+        {sessions.map((s) => (
+          <Box key={s.id} p={4} borderWidth="1px" borderRadius="md" bg="white">
+            <Heading size="md" mb={2}>
+              {s.title}
+            </Heading>
+            {s.description && <Text mb={2}>{s.description}</Text>}
+            <Text fontSize="sm">{new Date(s.date).toLocaleString()}</Text>
+          </Box>
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}

--- a/app/(dashboard)/opportunities/page.module.css
+++ b/app/(dashboard)/opportunities/page.module.css
@@ -1,0 +1,6 @@
+.container {
+  display: block;
+}
+.form {
+  max-width: 600px;
+}

--- a/app/(dashboard)/opportunities/page.tsx
+++ b/app/(dashboard)/opportunities/page.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  VStack,
+  HStack,
+  Heading,
+  StackDivider,
+} from "@chakra-ui/react";
+import api from "@/lib/api";
+import styles from "./page.module.css";
+
+interface Opportunity {
+  id: number;
+  title: string;
+  description: string;
+  startDate: string | null;
+  endDate: string | null;
+  skills: string | null;
+}
+
+export default function OpportunityManagementPage() {
+  const [opportunities, setOpportunities] = useState<Opportunity[]>([]);
+  const [form, setForm] = useState({
+    title: "",
+    description: "",
+    startDate: "",
+    endDate: "",
+    skills: "",
+  });
+
+  const load = () => {
+    api
+      .get<Opportunity[]>("/opportunities")
+      .then(setOpportunities)
+      .catch(console.error);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await api.post("/opportunities", form);
+    setForm({ title: "", description: "", startDate: "", endDate: "", skills: "" });
+    load();
+  };
+
+  return (
+    <Box className={styles.container}>
+      <Heading size="lg" mb={4}>
+        Opportunity Management
+      </Heading>
+      <form onSubmit={handleSubmit} className={styles.form}>
+        <VStack spacing={4} align="stretch">
+          <FormControl isRequired>
+            <FormLabel>Title</FormLabel>
+            <Input name="title" value={form.title} onChange={handleChange} />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Description</FormLabel>
+            <Textarea
+              name="description"
+              value={form.description}
+              onChange={handleChange}
+            />
+          </FormControl>
+          <HStack spacing={4}>
+            <FormControl>
+              <FormLabel>Start Date</FormLabel>
+              <Input
+                type="date"
+                name="startDate"
+                value={form.startDate}
+                onChange={handleChange}
+              />
+            </FormControl>
+            <FormControl>
+              <FormLabel>End Date</FormLabel>
+              <Input
+                type="date"
+                name="endDate"
+                value={form.endDate}
+                onChange={handleChange}
+              />
+            </FormControl>
+          </HStack>
+          <FormControl>
+            <FormLabel>Skills</FormLabel>
+            <Input name="skills" value={form.skills} onChange={handleChange} />
+          </FormControl>
+          <Button type="submit" colorScheme="brand" alignSelf="flex-start">
+            Create Opportunity
+          </Button>
+        </VStack>
+      </form>
+
+      <VStack mt={10} spacing={4} align="stretch" divider={<StackDivider />}>
+        {opportunities.map((opp) => (
+          <Box key={opp.id} p={4} bg="white" borderWidth="1px" borderRadius="md">
+            <Heading size="md" mb={2}>
+              {opp.title}
+            </Heading>
+            <p>{opp.description}</p>
+          </Box>
+        ))}
+      </VStack>
+    </Box>
+  );
+}

--- a/app/api/networking/route.ts
+++ b/app/api/networking/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import prisma from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const sessions = await prisma.networkingSession.findMany({
+    where: {
+      OR: [{ hostId: (session.user as any).id }],
+    },
+    orderBy: { date: "asc" },
+  });
+  return NextResponse.json(sessions);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const data = await req.json();
+  const record = await prisma.networkingSession.create({
+    data: {
+      title: data.title,
+      description: data.description,
+      date: new Date(data.date),
+      hostId: (session.user as any).id,
+    },
+  });
+
+  return NextResponse.json(record, { status: 201 });
+}

--- a/app/api/opportunities/route.ts
+++ b/app/api/opportunities/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import prisma from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const opportunities = await prisma.opportunity.findMany({
+    where: { employerId: (session.user as any).id },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return NextResponse.json(opportunities);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const data = await req.json();
+  const opportunity = await prisma.opportunity.create({
+    data: {
+      title: data.title,
+      description: data.description,
+      skills: data.skills,
+      startDate: data.startDate ? new Date(data.startDate) : null,
+      endDate: data.endDate ? new Date(data.endDate) : null,
+      employerId: (session.user as any).id,
+    },
+  });
+
+  return NextResponse.json(opportunity, { status: 201 });
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -20,6 +20,8 @@ export default function Sidebar() {
     { href: "/applications", label: "Applications" },
     { href: "/gigs", label: "Browse Gigs" },
     { href: "/gig-management", label: "Manage Gigs" },
+    { href: "/opportunities", label: "Opportunities" },
+    { href: "/networking", label: "Networking" },
   ];
 
   return (

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -187,3 +187,26 @@ model Interview {
   notes          String?
   createdAt      DateTime  @default(now())
 }
+
+model Opportunity {
+  id          Int      @id @default(autoincrement())
+  title       String
+  description String
+  employer    User     @relation(fields: [employerId], references: [id])
+  employerId  Int
+  skills      String?
+  startDate   DateTime?
+  endDate     DateTime?
+  status      String   @default("open")
+  createdAt   DateTime @default(now())
+}
+
+model NetworkingSession {
+  id          Int      @id @default(autoincrement())
+  title       String
+  description String?
+  date        DateTime
+  host        User     @relation(fields: [hostId], references: [id])
+  hostId      Int
+  createdAt   DateTime @default(now())
+}

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -133,6 +133,29 @@ async function main() {
       ],
       skipDuplicates: true,
     });
+
+    await prisma.opportunity.createMany({
+      data: [
+        {
+          title: 'Community Cleanup',
+          description: 'Organize local cleanup event',
+          employerId: admin.id,
+        },
+      ],
+      skipDuplicates: true,
+    });
+
+    await prisma.networkingSession.createMany({
+      data: [
+        {
+          title: 'Monthly Meetup',
+          description: 'Discuss upcoming projects',
+          date: new Date(),
+          hostId: admin.id,
+        },
+      ],
+      skipDuplicates: true,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- add Opportunity and NetworkingSession models
- expose /opportunities and /networking API routes
- build dashboard pages for opportunities and networking and link in sidebar

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68958d663cb48320a3e6946fd83787fa