### PR TITLE
Add volunteer opportunity search and tracking

### DIFF
--- a/app/(dashboard)/volunteer/applications/page.module.css
+++ b/app/(dashboard)/volunteer/applications/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  width: 100%;
+}

--- a/app/(dashboard)/volunteer/applications/page.tsx
+++ b/app/(dashboard)/volunteer/applications/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, Select, VStack } from "@chakra-ui/react";
+import VolunteerApplicationItem from "@/components/VolunteerApplicationItem";
+import { fetchJson } from "@/lib/fetcher";
+import styles from "./page.module.css";
+
+interface Application {
+  id: number;
+  status: string;
+  opportunity: {
+    title: string;
+    organization: string;
+  };
+  volunteer?: {
+    name?: string | null;
+  };
+}
+
+export default function VolunteerApplicationsPage() {
+  const [type, setType] = useState("my");
+  const [applications, setApplications] = useState<Application[]>([]);
+
+  useEffect(() => {
+    const query = type === "received" ? "?type=received" : "";
+    fetchJson<Application[]>(`/api/volunteer/applications${query}`).then(setApplications);
+  }, [type]);
+
+  return (
+    <Box className={styles.container}>
+      <Select value={type} onChange={(e) => setType(e.target.value)} mb={4} w="xs">
+        <option value="my">My Applications</option>
+        <option value="received">Received</option>
+      </Select>
+      <VStack spacing={4} align="stretch">
+        {applications.map((app) => (
+          <VolunteerApplicationItem key={app.id} application={app} />
+        ))}
+      </VStack>
+    </Box>
+  );
+}

--- a/app/(dashboard)/volunteer/opportunities/[id]/page.module.css
+++ b/app/(dashboard)/volunteer/opportunities/[id]/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  width: 100%;
+}

--- a/app/(dashboard)/volunteer/opportunities/[id]/page.tsx
+++ b/app/(dashboard)/volunteer/opportunities/[id]/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { Box, Heading, Text, Button } from "@chakra-ui/react";
+import { fetchJson } from "@/lib/fetcher";
+import styles from "./page.module.css";
+import { Opportunity } from "@/components/OpportunityCard";
+
+export default function OpportunityDetailsPage() {
+  const params = useParams();
+  const id = Array.isArray(params?.id) ? params.id[0] : params?.id;
+  const [opportunity, setOpportunity] = useState<Opportunity | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (id) {
+      fetchJson<Opportunity>(`/api/volunteer/opportunities/${id}`).then(setOpportunity);
+    }
+  }, [id]);
+
+  const apply = async () => {
+    if (!id) return;
+    setLoading(true);
+    try {
+      await fetchJson(`/api/volunteer/applications`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ opportunityId: Number(id) }),
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!opportunity) return null;
+
+  return (
+    <Box className={styles.container}>
+      <Heading>{opportunity.title}</Heading>
+      <Text color="gray.500">
+        {opportunity.organization}
+        {opportunity.location ? ` • ${opportunity.location}` : ""}
+      </Text>
+      <Text mt={4}>{opportunity.description}</Text>
+      <Button colorScheme="teal" mt={6} onClick={apply} isLoading={loading}>
+        Apply Now
+      </Button>
+    </Box>
+  );
+}

--- a/app/(dashboard)/volunteer/opportunities/page.module.css
+++ b/app/(dashboard)/volunteer/opportunities/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  width: 100%;
+}

--- a/app/(dashboard)/volunteer/opportunities/page.tsx
+++ b/app/(dashboard)/volunteer/opportunities/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, Input, SimpleGrid } from "@chakra-ui/react";
+import OpportunityCard, { Opportunity } from "@/components/OpportunityCard";
+import { fetchJson } from "@/lib/fetcher";
+import styles from "./page.module.css";
+
+export default function VolunteerOpportunitiesPage() {
+  const [keyword, setKeyword] = useState("");
+  const [opportunities, setOpportunities] = useState<Opportunity[]>([]);
+
+  useEffect(() => {
+    fetchJson<Opportunity[]>(`/api/volunteer/opportunities?q=${encodeURIComponent(keyword)}`).then(setOpportunities);
+  }, [keyword]);
+
+  return (
+    <Box className={styles.container}>
+      <Input
+        placeholder="Search opportunities"
+        value={keyword}
+        onChange={(e) => setKeyword(e.target.value)}
+        mb={4}
+      />
+      <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
+        {opportunities.map((op) => (
+          <OpportunityCard key={op.id} opportunity={op} />
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}

--- a/app/api/volunteer/applications/[id]/status/route.ts
+++ b/app/api/volunteer/applications/[id]/status/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { updateVolunteerApplicationStatus } from "@/lib/services/volunteerService";
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { status } = await req.json();
+  if (!status) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+  }
+  const updated = await updateVolunteerApplicationStatus(Number(params.id), status);
+  return NextResponse.json(updated);
+}

--- a/app/api/volunteer/applications/route.ts
+++ b/app/api/volunteer/applications/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import {
+  applyToOpportunity,
+  getMyVolunteerApplications,
+  getReceivedVolunteerApplications,
+} from "@/lib/services/volunteerService";
+
+export async function GET(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = Number(session.user.id);
+  const { searchParams } = new URL(req.url);
+  const type = searchParams.get("type");
+  const data =
+    type === "received"
+      ? await getReceivedVolunteerApplications(userId)
+      : await getMyVolunteerApplications(userId);
+  return NextResponse.json(data);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = Number(session.user.id);
+  const { opportunityId } = await req.json();
+  if (!opportunityId) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+  }
+  const application = await applyToOpportunity(Number(opportunityId), userId);
+  return NextResponse.json(application, { status: 201 });
+}

--- a/app/api/volunteer/opportunities/[id]/route.ts
+++ b/app/api/volunteer/opportunities/[id]/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getOpportunity } from "@/lib/services/volunteerService";
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const opportunity = await getOpportunity(Number(params.id));
+  if (!opportunity) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(opportunity);
+}

--- a/app/api/volunteer/opportunities/route.ts
+++ b/app/api/volunteer/opportunities/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { listOpportunities } from "@/lib/services/volunteerService";
+
+export async function GET(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { searchParams } = new URL(req.url);
+  const keyword = searchParams.get("q") || undefined;
+  const opportunities = await listOpportunities(keyword);
+  return NextResponse.json(opportunities);
+}

--- a/components/OpportunityCard.module.css
+++ b/components/OpportunityCard.module.css
@@ -1,0 +1,6 @@
+.card {
+  transition: box-shadow 0.2s ease-in-out;
+}
+.card:hover {
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}

--- a/components/OpportunityCard.tsx
+++ b/components/OpportunityCard.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Box, Heading, Text, Button } from "@chakra-ui/react";
+import Link from "next/link";
+import styles from "./OpportunityCard.module.css";
+
+export interface Opportunity {
+  id: number;
+  title: string;
+  organization: string;
+  location?: string | null;
+  description: string;
+}
+
+export default function OpportunityCard({ opportunity }: { opportunity: Opportunity }) {
+  return (
+    <Box className={styles.card} p={4} bg="white" borderWidth="1px" borderRadius="md">
+      <Heading size="md">{opportunity.title}</Heading>
+      <Text fontSize="sm" color="gray.500">
+        {opportunity.organization}
+        {opportunity.location ? ` • ${opportunity.location}` : ""}
+      </Text>
+      <Text mt={2}>{opportunity.description.slice(0, 100)}...</Text>
+      <Button as={Link} href={`/volunteer/opportunities/${opportunity.id}`} colorScheme="teal" mt={3}>
+        View Details
+      </Button>
+    </Box>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -20,6 +20,8 @@ export default function Sidebar() {
     { href: "/applications", label: "Applications" },
     { href: "/gigs", label: "Browse Gigs" },
     { href: "/gig-management", label: "Manage Gigs" },
+    { href: "/volunteer/opportunities", label: "Volunteer Opportunities" },
+    { href: "/volunteer/applications", label: "Volunteer Tracking" },
   ];
 
   return (

--- a/components/VolunteerApplicationItem.module.css
+++ b/components/VolunteerApplicationItem.module.css
@@ -1,0 +1,6 @@
+.item {
+  transition: background 0.2s ease-in-out;
+}
+.item:hover {
+  background: #f9fafb;
+}

--- a/components/VolunteerApplicationItem.tsx
+++ b/components/VolunteerApplicationItem.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Box, Heading, Text, Badge } from "@chakra-ui/react";
+import styles from "./VolunteerApplicationItem.module.css";
+
+interface VolunteerApplication {
+  id: number;
+  status: string;
+  opportunity: {
+    title: string;
+    organization: string;
+  };
+  volunteer?: {
+    name?: string | null;
+  };
+}
+
+export default function VolunteerApplicationItem({ application }: { application: VolunteerApplication }) {
+  const statusColor: Record<string, string> = {
+    pending: "yellow",
+    accepted: "green",
+    rejected: "red",
+  };
+
+  return (
+    <Box className={styles.item} p={4} bg="white" borderWidth="1px" borderRadius="md">
+      <Heading size="sm">{application.opportunity.title}</Heading>
+      <Text fontSize="sm" color="gray.500">
+        {application.opportunity.organization}
+        {application.volunteer && ` • ${application.volunteer.name ?? ""}`}
+      </Text>
+      <Badge mt={2} colorScheme={statusColor[application.status] || "gray"}>
+        {application.status}
+      </Badge>
+    </Box>
+  );
+}

--- a/lib/services/volunteerService.ts
+++ b/lib/services/volunteerService.ts
@@ -1,0 +1,46 @@
+import prisma from "@/lib/prisma";
+
+export async function listOpportunities(keyword?: string) {
+  return prisma.volunteerOpportunity.findMany({
+    where: keyword
+      ? {
+          OR: [
+            { title: { contains: keyword, mode: "insensitive" } },
+            { organization: { contains: keyword, mode: "insensitive" } },
+          ],
+        }
+      : undefined,
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+export async function getOpportunity(id: number) {
+  return prisma.volunteerOpportunity.findUnique({ where: { id } });
+}
+
+export async function applyToOpportunity(opportunityId: number, volunteerId: number) {
+  return prisma.volunteerApplication.create({
+    data: { opportunityId, volunteerId },
+  });
+}
+
+export async function getMyVolunteerApplications(userId: number) {
+  return prisma.volunteerApplication.findMany({
+    where: { volunteerId: userId },
+    include: { opportunity: true },
+  });
+}
+
+export async function getReceivedVolunteerApplications(userId: number) {
+  return prisma.volunteerApplication.findMany({
+    where: { opportunity: { creatorId: userId } },
+    include: { volunteer: true, opportunity: true },
+  });
+}
+
+export async function updateVolunteerApplicationStatus(id: number, status: string) {
+  return prisma.volunteerApplication.update({
+    where: { id },
+    data: { status },
+  });
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,31 +13,35 @@ enum Role {
 }
 
 model User {
-  id               Int               @id @default(autoincrement())
-  name             String?
-  email            String            @unique
-  role             Role              @default(jobSeeker)
-  password         String
-  phone            String?
-  location         String?
-  bio              String?
-  expertise        String?
-  payment          String?
-  taxId            String?
-  portfolio        String?
-  title            String?
-  image            String?
-  introVideo       String?
-  resume           String?
-  coverLetter      String?
-  notifications    Notification[]
-  projects         Project[]
-  subscriptions    Subscription[]
-  paymentMethods   PaymentMethod[]
-  transactions     Transaction[]
-  chatParticipants ChatParticipant[]
-  messages         Message[]
-  gigs             Gig[]
+  id                   Int                    @id @default(autoincrement())
+  name                 String?
+  email                String                 @unique
+  role                 Role                   @default(jobSeeker)
+  password             String
+  phone                String?
+  location             String?
+  bio                  String?
+  expertise            String?
+  payment              String?
+  taxId                String?
+  portfolio            String?
+  title                String?
+  image                String?
+  introVideo           String?
+  resume               String?
+  coverLetter          String?
+  notifications        Notification[]
+  projects             Project[]
+  subscriptions        Subscription[]
+  paymentMethods       PaymentMethod[]
+  transactions         Transaction[]
+  chatParticipants     ChatParticipant[]
+  messages             Message[]
+  gigs                 Gig[]
+  Job                  Job[]
+  Application          Application[]
+  VolunteerOpportunity VolunteerOpportunity[]
+  VolunteerApplication VolunteerApplication[]
 }
 
 model Testimonial {
@@ -55,7 +59,7 @@ model Feature {
 }
 
 model Solution {
-  id          Int    @id @default(autoincrement())
+  id          Int     @id @default(autoincrement())
   title       String
   description String
   imageUrl    String
@@ -157,33 +161,56 @@ model Gig {
 }
 
 model Job {
-  id        Int      @id @default(autoincrement())
-  title     String
-  employer  User     @relation(fields: [employerId], references: [id])
-  employerId Int
+  id           Int           @id @default(autoincrement())
+  title        String
+  employer     User          @relation(fields: [employerId], references: [id])
+  employerId   Int
   applications Application[]
-  createdAt DateTime @default(now())
+  createdAt    DateTime      @default(now())
 }
 
 model Application {
-  id          Int      @id @default(autoincrement())
-  job         Job      @relation(fields: [jobId], references: [id])
+  id          Int         @id @default(autoincrement())
+  job         Job         @relation(fields: [jobId], references: [id])
   jobId       Int
-  applicant   User     @relation(fields: [applicantId], references: [id])
+  applicant   User        @relation(fields: [applicantId], references: [id])
   applicantId Int
-  status      String   @default("pending")
+  status      String      @default("pending")
   interviews  Interview[]
-  createdAt   DateTime @default(now())
+  createdAt   DateTime    @default(now())
 }
 
 model Interview {
-  id             Int       @id @default(autoincrement())
-  application    Application @relation(fields: [applicationId], references: [id])
-  applicationId  Int
-  scheduledAt    DateTime
-  location       String?
-  link           String?
-  status         String    @default("scheduled")
-  notes          String?
-  createdAt      DateTime  @default(now())
+  id            Int         @id @default(autoincrement())
+  application   Application @relation(fields: [applicationId], references: [id])
+  applicationId Int
+  scheduledAt   DateTime
+  location      String?
+  link          String?
+  status        String      @default("scheduled")
+  notes         String?
+  createdAt     DateTime    @default(now())
+}
+
+model VolunteerOpportunity {
+  id           Int                    @id @default(autoincrement())
+  title        String
+  organization String
+  location     String?
+  description  String
+  date         DateTime?
+  creator      User                   @relation(fields: [creatorId], references: [id])
+  creatorId    Int
+  applications VolunteerApplication[]
+  createdAt    DateTime               @default(now())
+}
+
+model VolunteerApplication {
+  id            Int                  @id @default(autoincrement())
+  opportunity   VolunteerOpportunity @relation(fields: [opportunityId], references: [id])
+  opportunityId Int
+  volunteer     User                 @relation(fields: [volunteerId], references: [id])
+  volunteerId   Int
+  status        String               @default("pending")
+  createdAt     DateTime             @default(now())
 }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -133,6 +133,26 @@ async function main() {
       ],
       skipDuplicates: true,
     });
+
+    await prisma.volunteerOpportunity.createMany({
+      data: [
+        {
+          title: 'Community Clean-Up',
+          organization: 'City Helpers',
+          location: 'Remote',
+          description: 'Assist in organizing a community clean-up event.',
+          creatorId: admin.id,
+        },
+        {
+          title: 'Food Bank Support',
+          organization: 'Helping Hands',
+          location: 'New York',
+          description: 'Help sort and pack food donations for families in need.',
+          creatorId: admin.id,
+        },
+      ],
+      skipDuplicates: true,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- add Prisma models for volunteer opportunities and applications
- implement service layer and API routes for listing opportunities and managing applications
- create Chakra UI pages for searching opportunities and tracking volunteer applications
- integrate volunteer features into sidebar navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68958d5771208320bae14a1306572896