### PR TITLE
Add progress and volunteering dashboards

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -66,6 +66,12 @@ export default function DashboardPage() {
         <Button as={Link} href="/applications" colorScheme="brand" variant="outline">
           Applications
         </Button>
+        <Button as={Link} href="/progress" colorScheme="brand" variant="outline">
+          Progress
+        </Button>
+        <Button as={Link} href="/volunteering" colorScheme="brand" variant="outline">
+          Volunteering
+        </Button>
       </HStack>
       <SimpleGrid columns={{ base: 1, md: 3 }} spacing={6} mb={10}>
         <DashboardCard title="Users">

--- a/app/(dashboard)/progress/page.module.css
+++ b/app/(dashboard)/progress/page.module.css
@@ -1,0 +1,4 @@
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+}

--- a/app/(dashboard)/progress/page.tsx
+++ b/app/(dashboard)/progress/page.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Heading,
+  SimpleGrid,
+  Spinner,
+  Text,
+} from "@chakra-ui/react";
+import DashboardCard from "@/components/DashboardCard";
+import { ParticipantProgress, ProviderProgress } from "@/lib/types/progress";
+import progressService from "@/lib/services/progressService";
+import styles from "./page.module.css";
+
+export default function ProgressPage() {
+  const [view, setView] = useState<"participant" | "provider">("participant");
+  const [participant, setParticipant] = useState<ParticipantProgress>();
+  const [provider, setProvider] = useState<ProviderProgress>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const loadData = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      if (view === "participant") {
+        const data = await progressService.getParticipant();
+        setParticipant(data);
+      } else {
+        const data = await progressService.getProvider();
+        setProvider(data);
+      }
+    } catch (e: any) {
+      setError(e.message || "Failed to load progress");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [view]);
+
+  return (
+    <Box className={styles.container}>
+      <Heading size="lg" mb={4}>
+        Progress Dashboard
+      </Heading>
+      <ButtonGroup mb={4}>
+        <Button
+          colorScheme={view === "participant" ? "brand" : "gray"}
+          onClick={() => setView("participant")}
+        >
+          Participant View
+        </Button>
+        <Button
+          colorScheme={view === "provider" ? "brand" : "gray"}
+          onClick={() => setView("provider")}
+        >
+          Provider View
+        </Button>
+      </ButtonGroup>
+      {error && (
+        <Text color="red.500" mb={4}>
+          {error}
+        </Text>
+      )}
+      {loading ? (
+        <Spinner />
+      ) : (
+        <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4}>
+          {view === "participant" && participant && (
+            <>
+              <DashboardCard title="Completed Tasks">
+                <Text fontSize="2xl">{participant.completedTasks}</Text>
+              </DashboardCard>
+              <DashboardCard title="Average Rating">
+                <Text fontSize="2xl">{participant.averageRating.toFixed(1)}</Text>
+              </DashboardCard>
+              <DashboardCard title="Badges Earned">
+                <Text fontSize="2xl">{participant.badges}</Text>
+              </DashboardCard>
+            </>
+          )}
+          {view === "provider" && provider && (
+            <>
+              <DashboardCard title="Participants Tracked">
+                <Text fontSize="2xl">{provider.participants}</Text>
+              </DashboardCard>
+              <DashboardCard title="Average Feedback">
+                <Text fontSize="2xl">{provider.averageFeedback.toFixed(1)}</Text>
+              </DashboardCard>
+              <DashboardCard title="Projects Managed">
+                <Text fontSize="2xl">{provider.projectsManaged}</Text>
+              </DashboardCard>
+            </>
+          )}
+        </SimpleGrid>
+      )}
+    </Box>
+  );
+}

--- a/app/(dashboard)/volunteering/page.module.css
+++ b/app/(dashboard)/volunteering/page.module.css
@@ -1,0 +1,4 @@
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+}

--- a/app/(dashboard)/volunteering/page.tsx
+++ b/app/(dashboard)/volunteering/page.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Heading,
+  SimpleGrid,
+  Spinner,
+  Text,
+} from "@chakra-ui/react";
+import DashboardCard from "@/components/DashboardCard";
+import { VolunteerStats, EmployerStats } from "@/lib/types/volunteer";
+import volunteerService from "@/lib/services/volunteerService";
+import styles from "./page.module.css";
+
+export default function VolunteeringDashboard() {
+  const [view, setView] = useState<"volunteer" | "employer">("volunteer");
+  const [volunteer, setVolunteer] = useState<VolunteerStats>();
+  const [employer, setEmployer] = useState<EmployerStats>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const loadData = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      if (view === "volunteer") {
+        const data = await volunteerService.getVolunteerStats();
+        setVolunteer(data);
+      } else {
+        const data = await volunteerService.getEmployerStats();
+        setEmployer(data);
+      }
+    } catch (e: any) {
+      setError(e.message || "Failed to load stats");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [view]);
+
+  return (
+    <Box className={styles.container}>
+      <Heading size="lg" mb={4}>
+        Volunteering Dashboard
+      </Heading>
+      <ButtonGroup mb={4}>
+        <Button
+          colorScheme={view === "volunteer" ? "brand" : "gray"}
+          onClick={() => setView("volunteer")}
+        >
+          Volunteer View
+        </Button>
+        <Button
+          colorScheme={view === "employer" ? "brand" : "gray"}
+          onClick={() => setView("employer")}
+        >
+          Employer View
+        </Button>
+      </ButtonGroup>
+      {error && (
+        <Text color="red.500" mb={4}>
+          {error}
+        </Text>
+      )}
+      {loading ? (
+        <Spinner />
+      ) : (
+        <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4}>
+          {view === "volunteer" && volunteer && (
+            <>
+              <DashboardCard title="Total Hours">
+                <Text fontSize="2xl">{volunteer.totalHours}</Text>
+              </DashboardCard>
+              <DashboardCard title="Active Applications">
+                <Text fontSize="2xl">{volunteer.activeApplications}</Text>
+              </DashboardCard>
+              <DashboardCard title="Feedback Score">
+                <Text fontSize="2xl">{volunteer.feedbackScore.toFixed(1)}</Text>
+              </DashboardCard>
+            </>
+          )}
+          {view === "employer" && employer && (
+            <>
+              <DashboardCard title="Active Volunteers">
+                <Text fontSize="2xl">{employer.activeVolunteers}</Text>
+              </DashboardCard>
+              <DashboardCard title="Active Opportunities">
+                <Text fontSize="2xl">{employer.activeOpportunities}</Text>
+              </DashboardCard>
+              <DashboardCard title="Pending Applications">
+                <Text fontSize="2xl">{employer.pendingApplications}</Text>
+              </DashboardCard>
+            </>
+          )}
+        </SimpleGrid>
+      )}
+    </Box>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -20,6 +20,8 @@ export default function Sidebar() {
     { href: "/applications", label: "Applications" },
     { href: "/gigs", label: "Browse Gigs" },
     { href: "/gig-management", label: "Manage Gigs" },
+    { href: "/progress", label: "Progress" },
+    { href: "/volunteering", label: "Volunteering" },
   ];
 
   return (

--- a/lib/services/progressService.ts
+++ b/lib/services/progressService.ts
@@ -1,0 +1,9 @@
+import api from "@/lib/api";
+import { ParticipantProgress, ProviderProgress } from "@/lib/types/progress";
+
+export const progressService = {
+  getParticipant: () => api.get<ParticipantProgress>("/progress/participant"),
+  getProvider: () => api.get<ProviderProgress>("/progress/provider"),
+};
+
+export default progressService;

--- a/lib/services/volunteerService.ts
+++ b/lib/services/volunteerService.ts
@@ -1,0 +1,9 @@
+import api from "@/lib/api";
+import { VolunteerStats, EmployerStats } from "@/lib/types/volunteer";
+
+export const volunteerService = {
+  getVolunteerStats: () => api.get<VolunteerStats>("/volunteering/volunteer/stats"),
+  getEmployerStats: () => api.get<EmployerStats>("/volunteering/employer/stats"),
+};
+
+export default volunteerService;

--- a/lib/types/progress.ts
+++ b/lib/types/progress.ts
@@ -1,0 +1,11 @@
+export interface ParticipantProgress {
+  completedTasks: number;
+  averageRating: number;
+  badges: number;
+}
+
+export interface ProviderProgress {
+  participants: number;
+  averageFeedback: number;
+  projectsManaged: number;
+}

--- a/lib/types/volunteer.ts
+++ b/lib/types/volunteer.ts
@@ -1,0 +1,11 @@
+export interface VolunteerStats {
+  totalHours: number;
+  activeApplications: number;
+  feedbackScore: number;
+}
+
+export interface EmployerStats {
+  activeVolunteers: number;
+  activeOpportunities: number;
+  pendingApplications: number;
+}


### PR DESCRIPTION
## Summary
- Implement participant and provider progress dashboard with API integration and role toggle
- Introduce volunteering dashboard supporting volunteer and employer metrics
- Update navigation and services to support new pages

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68958d48b9e083208fa9ba69e06611a2