### PR TITLE
Add task marketplace pages and API

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -60,6 +60,9 @@ export default function DashboardPage() {
         <Button as={Link} href="/gig-management" colorScheme="brand" variant="outline">
           Manage Gigs
         </Button>
+        <Button as={Link} href="/tasks" colorScheme="brand" variant="outline">
+          Tasks
+        </Button>
         <Button as={Link} href="/messages" colorScheme="brand" variant="outline">
           Messages
         </Button>

--- a/app/(dashboard)/tasks/[id]/page.module.css
+++ b/app/(dashboard)/tasks/[id]/page.module.css
@@ -1,0 +1,8 @@
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+.spinner {
+  display: block;
+  margin: 2rem auto;
+}

--- a/app/(dashboard)/tasks/[id]/page.tsx
+++ b/app/(dashboard)/tasks/[id]/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import {
+  Box,
+  Heading,
+  Text,
+  Stack,
+  FormControl,
+  FormLabel,
+  NumberInput,
+  NumberInputField,
+  Textarea,
+  Button,
+  useToast,
+  Spinner,
+} from "@chakra-ui/react";
+import api from "@/lib/api";
+import { Task } from "@/lib/types/task";
+import styles from "./page.module.css";
+
+interface DetailedTask extends Task {
+  bids: { id: number; amount: number; message?: string; bidder: { id: number; name: string | null } }[];
+  creator: { id: number; name: string | null };
+}
+
+export default function TaskDetailPage() {
+  const params = useParams<{ id: string }>();
+  const [task, setTask] = useState<DetailedTask | null>(null);
+  const [amount, setAmount] = useState("");
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const toast = useToast();
+
+  const loadTask = async () => {
+    try {
+      const data = await api.get<DetailedTask>(`/tasks/${params.id}`);
+      setTask(data);
+    } catch (err: any) {
+      toast({ status: "error", title: err.message || "Failed to load task" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadTask();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params.id]);
+
+  const submitBid = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      await api.post(`/tasks/${params.id}/bids`, {
+        amount: Number(amount),
+        message: message || undefined,
+      });
+      toast({ status: "success", title: "Bid submitted" });
+      setAmount("");
+      setMessage("");
+      loadTask();
+    } catch (err: any) {
+      toast({ status: "error", title: err.message || "Failed to submit bid" });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading || !task) return <Spinner className={styles.spinner} />;
+
+  return (
+    <Box className={styles.container}>
+      <Heading mb={4}>{task.title}</Heading>
+      <Text mb={4}>{task.description}</Text>
+      <Stack spacing={2} mb={6}>
+        {(task.budgetMin || task.budgetMax) && (
+          <Text>
+            Budget: {task.budgetMin ? `$${task.budgetMin}` : ""} {task.budgetMax ? `- $${task.budgetMax}` : ""}
+          </Text>
+        )}
+        {task.deadline && <Text>Deadline: {new Date(task.deadline).toLocaleDateString()}</Text>}
+        <Text>Posted by: {task.creator?.name}</Text>
+      </Stack>
+      <form onSubmit={submitBid}>
+        <Stack spacing={4}>
+          <FormControl isRequired>
+            <FormLabel>Bid Amount</FormLabel>
+            <NumberInput min={0} value={amount} onChange={(v) => setAmount(v)}>
+              <NumberInputField />
+            </NumberInput>
+          </FormControl>
+          <FormControl>
+            <FormLabel>Message</FormLabel>
+            <Textarea value={message} onChange={(e) => setMessage(e.target.value)} />
+          </FormControl>
+          <Button type="submit" colorScheme="brand" isLoading={submitting}>
+            Place Bid
+          </Button>
+        </Stack>
+      </form>
+      {task.bids.length > 0 && (
+        <Box mt={10}>
+          <Heading size="md" mb={4}>
+            Bids
+          </Heading>
+          <Stack spacing={3}>
+            {task.bids.map((bid) => (
+              <Box key={bid.id} borderWidth="1px" borderRadius="md" p={3}>
+                <Text fontWeight="bold">${bid.amount}</Text>
+                {bid.message && <Text>{bid.message}</Text>}
+                <Text fontSize="sm">By {bid.bidder?.name}</Text>
+              </Box>
+            ))}
+          </Stack>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/app/(dashboard)/tasks/create/page.module.css
+++ b/app/(dashboard)/tasks/create/page.module.css
@@ -1,0 +1,4 @@
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+}

--- a/app/(dashboard)/tasks/create/page.tsx
+++ b/app/(dashboard)/tasks/create/page.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  Button,
+  Stack,
+  HStack,
+  NumberInput,
+  NumberInputField,
+  useToast,
+} from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import api from "@/lib/api";
+import styles from "./page.module.css";
+
+export default function TaskCreatePage() {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [budgetMin, setBudgetMin] = useState("");
+  const [budgetMax, setBudgetMax] = useState("");
+  const [deadline, setDeadline] = useState("");
+  const [loading, setLoading] = useState(false);
+  const toast = useToast();
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await api.post("/tasks", {
+        title,
+        description,
+        budgetMin: budgetMin ? Number(budgetMin) : undefined,
+        budgetMax: budgetMax ? Number(budgetMax) : undefined,
+        deadline: deadline || undefined,
+      });
+      toast({ status: "success", title: "Task created" });
+      router.push("/tasks");
+    } catch (err: any) {
+      toast({ status: "error", title: err.message || "Failed to create task" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box className={styles.container}>
+      <form onSubmit={handleSubmit}>
+        <Stack spacing={4}>
+          <FormControl isRequired>
+            <FormLabel>Title</FormLabel>
+            <Input value={title} onChange={(e) => setTitle(e.target.value)} />
+          </FormControl>
+          <FormControl isRequired>
+            <FormLabel>Description</FormLabel>
+            <Textarea value={description} onChange={(e) => setDescription(e.target.value)} />
+          </FormControl>
+          <HStack spacing={4}>
+            <FormControl>
+              <FormLabel>Min Budget</FormLabel>
+              <NumberInput min={0} value={budgetMin} onChange={(v) => setBudgetMin(v)}>
+                <NumberInputField />
+              </NumberInput>
+            </FormControl>
+            <FormControl>
+              <FormLabel>Max Budget</FormLabel>
+              <NumberInput min={0} value={budgetMax} onChange={(v) => setBudgetMax(v)}>
+                <NumberInputField />
+              </NumberInput>
+            </FormControl>
+          </HStack>
+          <FormControl>
+            <FormLabel>Deadline</FormLabel>
+            <Input type="date" value={deadline} onChange={(e) => setDeadline(e.target.value)} />
+          </FormControl>
+          <Button type="submit" colorScheme="brand" isLoading={loading}>
+            Publish Task
+          </Button>
+        </Stack>
+      </form>
+    </Box>
+  );
+}

--- a/app/(dashboard)/tasks/page.module.css
+++ b/app/(dashboard)/tasks/page.module.css
@@ -1,0 +1,7 @@
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+.searchForm {
+  flex: 1;
+}

--- a/app/(dashboard)/tasks/page.tsx
+++ b/app/(dashboard)/tasks/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  FormControl,
+  FormLabel,
+  Input,
+  SimpleGrid,
+  Button,
+  Text,
+  Spinner,
+  HStack,
+} from "@chakra-ui/react";
+import Link from "next/link";
+import api from "@/lib/api";
+import TaskCard from "@/components/TaskCard";
+import { Task } from "@/lib/types/task";
+import styles from "./page.module.css";
+
+export default function TaskBrowsePage() {
+  const [search, setSearch] = useState("");
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const loadTasks = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const params = new URLSearchParams();
+      if (search) params.set("search", search);
+      const data = await api.get<Task[]>(`/tasks?${params.toString()}`);
+      setTasks(data);
+    } catch (err: any) {
+      setError(err.message || "Failed to load tasks");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadTasks();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <Box className={styles.container}>
+      <HStack justify="space-between" align="flex-end" mb={4}>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            loadTasks();
+          }}
+          className={styles.searchForm}
+        >
+          <FormControl>
+            <FormLabel>Search</FormLabel>
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search tasks"
+            />
+          </FormControl>
+        </form>
+        <Button colorScheme="brand" onClick={loadTasks}>
+          Apply
+        </Button>
+        <Button as={Link} href="/tasks/create" colorScheme="brand" variant="outline">
+          New Task
+        </Button>
+      </HStack>
+      {error && (
+        <Text color="red.500" mt={4}>
+          {error}
+        </Text>
+      )}
+      {loading ? (
+        <Spinner mt={4} />
+      ) : (
+        <SimpleGrid columns={{ base: 1, sm: 2, md: 3 }} spacing={4} mt={4}>
+          {tasks.map((task) => (
+            <TaskCard key={task.id} task={task} />
+          ))}
+        </SimpleGrid>
+      )}
+    </Box>
+  );
+}

--- a/app/api/tasks/[id]/bids/route.ts
+++ b/app/api/tasks/[id]/bids/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { createTaskBid } from "@/lib/services/taskService";
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  const bidderId = session?.user?.id ? Number(session.user.id) : undefined;
+  if (!bidderId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const taskId = Number(params.id);
+  if (isNaN(taskId)) {
+    return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+  }
+  const { amount, message, timeline } = await req.json();
+  if (typeof amount !== "number") {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+  }
+  const bid = await createTaskBid({ taskId, bidderId, amount, message, timeline });
+  return NextResponse.json(bid, { status: 201 });
+}

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { getTask } from "@/lib/services/taskService";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const id = Number(params.id);
+  if (isNaN(id)) {
+    return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+  }
+  const task = await getTask(id);
+  if (!task) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(task);
+}

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getTasks, createTask } from "@/lib/services/taskService";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const filters = {
+    search: searchParams.get("search") || undefined,
+    category: searchParams.get("category") || undefined,
+  };
+  const tasks = await getTasks(filters);
+  return NextResponse.json(tasks);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  const creatorId = session?.user?.id ? Number(session.user.id) : undefined;
+  if (!creatorId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const {
+    title,
+    description,
+    category,
+    skills,
+    budgetMin,
+    budgetMax,
+    paymentMethod,
+    deadline,
+    media,
+    visibility,
+  } = await req.json();
+
+  if (!title || !description) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+  }
+
+  const task = await createTask({
+    title,
+    description,
+    category,
+    skills,
+    budgetMin,
+    budgetMax,
+    paymentMethod,
+    deadline: deadline ? new Date(deadline) : undefined,
+    media,
+    visibility,
+    creatorId,
+  });
+
+  return NextResponse.json(task, { status: 201 });
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -20,6 +20,7 @@ export default function Sidebar() {
     { href: "/applications", label: "Applications" },
     { href: "/gigs", label: "Browse Gigs" },
     { href: "/gig-management", label: "Manage Gigs" },
+    { href: "/tasks", label: "Tasks" },
   ];
 
   return (

--- a/components/TaskCard.module.css
+++ b/components/TaskCard.module.css
@@ -1,0 +1,6 @@
+.card {
+  background: #fff;
+}
+.budget {
+  font-weight: 600;
+}

--- a/components/TaskCard.tsx
+++ b/components/TaskCard.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Box, Heading, Text, Stack, Button } from "@chakra-ui/react";
+import Link from "next/link";
+import { Task } from "@/lib/types/task";
+import styles from "./TaskCard.module.css";
+
+export default function TaskCard({ task }: { task: Task }) {
+  return (
+    <Box borderWidth="1px" borderRadius="md" p={4} className={styles.card}>
+      <Stack spacing={2}>
+        <Heading size="md">{task.title}</Heading>
+        <Text noOfLines={2}>{task.description}</Text>
+        {(task.budgetMin || task.budgetMax) && (
+          <Text className={styles.budget}>
+            Budget:
+            {task.budgetMin ? ` $${task.budgetMin}` : ""}
+            {task.budgetMax ? ` - $${task.budgetMax}` : ""}
+          </Text>
+        )}
+        {task.deadline && (
+          <Text>Deadline: {new Date(task.deadline).toLocaleDateString()}</Text>
+        )}
+        <Button as={Link} href={`/tasks/${task.id}`} colorScheme="brand" size="sm">
+          View Details
+        </Button>
+      </Stack>
+    </Box>
+  );
+}

--- a/lib/services/taskService.ts
+++ b/lib/services/taskService.ts
@@ -1,0 +1,62 @@
+import prisma from "@/lib/prisma";
+
+export interface TaskFilters {
+  search?: string;
+  category?: string;
+}
+
+export async function getTasks(filters: TaskFilters = {}) {
+  const { search, category } = filters;
+  return prisma.task.findMany({
+    where: {
+      ...(search ? { title: { contains: search, mode: "insensitive" } } : {}),
+      ...(category ? { category } : {}),
+      status: "open",
+    },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+export interface CreateTaskData {
+  title: string;
+  description: string;
+  category?: string;
+  skills?: string[];
+  budgetMin?: number;
+  budgetMax?: number;
+  paymentMethod?: string;
+  deadline?: Date;
+  media?: string[];
+  visibility?: string;
+  creatorId: number;
+}
+
+export async function createTask(data: CreateTaskData) {
+  return prisma.task.create({ data });
+}
+
+export async function getTask(id: number) {
+  return prisma.task.findUnique({
+    where: { id },
+    include: {
+      creator: { select: { id: true, name: true, image: true } },
+      bids: {
+        include: {
+          bidder: { select: { id: true, name: true, image: true } },
+        },
+      },
+    },
+  });
+}
+
+export interface CreateBidData {
+  taskId: number;
+  bidderId: number;
+  amount: number;
+  message?: string;
+  timeline?: string;
+}
+
+export async function createTaskBid(data: CreateBidData) {
+  return prisma.taskBid.create({ data });
+}

--- a/lib/types/task.ts
+++ b/lib/types/task.ts
@@ -1,0 +1,27 @@
+export interface Task {
+  id: number;
+  title: string;
+  description: string;
+  category?: string | null;
+  skills: string[];
+  budgetMin?: number | null;
+  budgetMax?: number | null;
+  paymentMethod?: string | null;
+  deadline?: string | null;
+  media: string[];
+  visibility: string;
+  creatorId: number;
+  status: string;
+  createdAt: string;
+}
+
+export interface TaskBid {
+  id: number;
+  taskId: number;
+  bidderId: number;
+  amount: number;
+  message?: string | null;
+  timeline?: string | null;
+  status: string;
+  createdAt: string;
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,10 @@ model User {
   chatParticipants ChatParticipant[]
   messages         Message[]
   gigs             Gig[]
+  jobs             Job[]       @relation("JobEmployer")
+  applications     Application[] @relation("ApplicationApplicant")
+  tasks            Task[]      @relation("TaskCreator")
+  bids             TaskBid[]   @relation("TaskBidder")
 }
 
 model Testimonial {
@@ -159,7 +163,7 @@ model Gig {
 model Job {
   id        Int      @id @default(autoincrement())
   title     String
-  employer  User     @relation(fields: [employerId], references: [id])
+  employer  User     @relation("JobEmployer", fields: [employerId], references: [id])
   employerId Int
   applications Application[]
   createdAt DateTime @default(now())
@@ -169,7 +173,7 @@ model Application {
   id          Int      @id @default(autoincrement())
   job         Job      @relation(fields: [jobId], references: [id])
   jobId       Int
-  applicant   User     @relation(fields: [applicantId], references: [id])
+  applicant   User     @relation("ApplicationApplicant", fields: [applicantId], references: [id])
   applicantId Int
   status      String   @default("pending")
   interviews  Interview[]
@@ -186,4 +190,36 @@ model Interview {
   status         String    @default("scheduled")
   notes          String?
   createdAt      DateTime  @default(now())
+}
+
+model Task {
+  id           Int       @id @default(autoincrement())
+  title        String
+  description  String
+  category     String?
+  skills       String[]
+  budgetMin    Int?
+  budgetMax    Int?
+  paymentMethod String?
+  deadline     DateTime?
+  media        String[]
+  visibility   String    @default("public")
+  creator      User      @relation("TaskCreator", fields: [creatorId], references: [id])
+  creatorId    Int
+  bids         TaskBid[]
+  status       String    @default("open")
+  createdAt    DateTime  @default(now())
+}
+
+model TaskBid {
+  id        Int      @id @default(autoincrement())
+  task      Task     @relation(fields: [taskId], references: [id])
+  taskId    Int
+  bidder    User     @relation("TaskBidder", fields: [bidderId], references: [id])
+  bidderId  Int
+  amount    Int
+  message   String?
+  timeline  String?
+  status    String   @default("pending")
+  createdAt DateTime @default(now())
 }


### PR DESCRIPTION
## Summary
- add Prisma models for tasks and bids
- implement task API routes for listing, creating, retrieving tasks and submitting bids
- build task browsing, creation, and detail pages with Chakra UI and TaskCard component
- link tasks into sidebar and dashboard navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68958d1e22b083208c6459b762a45405