### PR TITLE
feat: add task scheduling and experience dashboards

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -66,6 +66,12 @@ export default function DashboardPage() {
         <Button as={Link} href="/applications" colorScheme="brand" variant="outline">
           Applications
         </Button>
+        <Button as={Link} href="/tasks" colorScheme="brand" variant="outline">
+          Tasks
+        </Button>
+        <Button as={Link} href="/experience" colorScheme="brand" variant="outline">
+          Experience
+        </Button>
       </HStack>
       <SimpleGrid columns={{ base: 1, md: 3 }} spacing={6} mb={10}>
         <DashboardCard title="Users">

--- a/app/(dashboard)/experience/page.module.css
+++ b/app/(dashboard)/experience/page.module.css
@@ -1,0 +1,6 @@
+.container {
+  width: 100%;
+}
+.stats {
+  margin-bottom: 1rem;
+}

--- a/app/(dashboard)/experience/page.tsx
+++ b/app/(dashboard)/experience/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Heading,
+  SimpleGrid,
+  Stat,
+  StatLabel,
+  StatNumber,
+  VStack,
+  Text,
+  Button,
+} from "@chakra-ui/react";
+import Link from "next/link";
+import api from "@/lib/api";
+import { ExperienceSummary } from "@/lib/types/experience";
+import { Gig } from "@/lib/types/gig";
+import styles from "./page.module.css";
+
+export default function ExperienceDashboard() {
+  const [summary, setSummary] = useState<ExperienceSummary | null>(null);
+  const [gigs, setGigs] = useState<Gig[]>([]);
+
+  useEffect(() => {
+    api.get<ExperienceSummary>("/experience").then(setSummary).catch(console.error);
+    api.get<Gig[]>("/gigs").then(setGigs).catch(console.error);
+  }, []);
+
+  return (
+    <Box className={styles.container}>
+      <Heading size="md" mb={6}>
+        Experience Dashboard
+      </Heading>
+      {summary && (
+        <SimpleGrid columns={{ base: 1, md: 2 }} spacing={6} className={styles.stats}>
+          <Stat>
+            <StatLabel>Tasks Completed</StatLabel>
+            <StatNumber>{summary.participant.totalCompleted}</StatNumber>
+          </Stat>
+          <Stat>
+            <StatLabel>Average Rating</StatLabel>
+            <StatNumber>{summary.participant.avgRating.toFixed(2)}</StatNumber>
+          </Stat>
+          <Stat>
+            <StatLabel>Active Opportunities</StatLabel>
+            <StatNumber>{summary.provider.activeOpportunities}</StatNumber>
+          </Stat>
+          <Stat>
+            <StatLabel>Applications</StatLabel>
+            <StatNumber>{summary.provider.applications}</StatNumber>
+          </Stat>
+        </SimpleGrid>
+      )}
+
+      <VStack align="stretch" spacing={4} mb={6}>
+        <Heading size="sm">Recommended Gigs</Heading>
+        {gigs.slice(0, 3).map((gig) => (
+          <Box key={gig.id} p={3} borderWidth="1px" borderRadius="md">
+            <Text fontWeight="bold">{gig.title}</Text>
+            <Text>${gig.price}</Text>
+          </Box>
+        ))}
+      </VStack>
+
+      <Button as={Link} href="/gigs" colorScheme="brand">
+        View All Gigs
+      </Button>
+    </Box>
+  );
+}

--- a/app/(dashboard)/tasks/page.module.css
+++ b/app/(dashboard)/tasks/page.module.css
@@ -1,0 +1,9 @@
+.container {
+  width: 100%;
+}
+.taskRow:hover {
+  background-color: #f7fafc;
+}
+.calendar {
+  margin-top: 1rem;
+}

--- a/app/(dashboard)/tasks/page.tsx
+++ b/app/(dashboard)/tasks/page.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Heading,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+  Text,
+  useDisclosure,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Input,
+  Stack,
+} from "@chakra-ui/react";
+import api from "@/lib/api";
+import { Task } from "@/lib/types/task";
+import styles from "./page.module.css";
+
+export default function TaskSchedulePage() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [selected, setSelected] = useState<Task | null>(null);
+  const [newDate, setNewDate] = useState("");
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  useEffect(() => {
+    api.get<Task[]>("/tasks").then(setTasks).catch(console.error);
+  }, []);
+
+  const active = tasks.filter((t) => t.status !== "completed");
+  const completed = tasks.filter((t) => t.status === "completed");
+
+  const openReschedule = (task: Task) => {
+    setSelected(task);
+    setNewDate(task.deadline.split("T")[0]);
+    onOpen();
+  };
+
+  const reschedule = async () => {
+    if (!selected) return;
+    await api.put(`/tasks/${selected.id}`, { deadline: newDate });
+    setTasks((prev) =>
+      prev.map((t) =>
+        t.id === selected.id ? { ...t, deadline: newDate } : t
+      )
+    );
+    onClose();
+  };
+
+  const markComplete = async (task: Task) => {
+    await api.put(`/tasks/${task.id}`, { status: "completed" });
+    setTasks((prev) =>
+      prev.map((t) =>
+        t.id === task.id ? { ...t, status: "completed" } : t
+      )
+    );
+  };
+
+  const daysInMonth = () => {
+    const date = new Date();
+    const year = date.getFullYear();
+    const month = date.getMonth();
+    const firstDay = new Date(year, month, 1).getDay();
+    const numDays = new Date(year, month + 1, 0).getDate();
+    const cells: (Task[] | null)[] = Array(firstDay).fill(null);
+    for (let d = 1; d <= numDays; d++) {
+      const dayTasks = active.filter(
+        (t) => new Date(t.deadline).getDate() === d
+      );
+      cells.push(dayTasks);
+    }
+    return cells;
+  };
+
+  return (
+    <Box className={styles.container}>
+      <Heading size="md" mb={4}>
+        Task & Schedule Management
+      </Heading>
+      <Tabs variant="enclosed">
+        <TabList>
+          <Tab>Active Tasks</Tab>
+          <Tab>Schedule</Tab>
+          <Tab>Completed</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <Table variant="simple">
+              <Thead>
+                <Tr>
+                  <Th>Title</Th>
+                  <Th>Deadline</Th>
+                  <Th>Payment</Th>
+                  <Th>Actions</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {active.map((task) => (
+                  <Tr key={task.id} className={styles.taskRow}>
+                    <Td>{task.title}</Td>
+                    <Td>{new Date(task.deadline).toLocaleDateString()}</Td>
+                    <Td>${task.payment}</Td>
+                    <Td>
+                      <Stack direction="row" spacing={2}>
+                        {task.reschedulable && (
+                          <Button size="sm" onClick={() => openReschedule(task)}>
+                            Reschedule
+                          </Button>
+                        )}
+                        <Button
+                          size="sm"
+                          colorScheme="green"
+                          onClick={() => markComplete(task)}
+                        >
+                          Complete
+                        </Button>
+                      </Stack>
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </TabPanel>
+          <TabPanel>
+            <Box className={styles.calendar}>
+              <Table size="sm">
+                <Tbody>
+                  {(() => {
+                    const cells = daysInMonth();
+                    const rows = [];
+                    for (let i = 0; i < cells.length; i += 7) {
+                      rows.push(cells.slice(i, i + 7));
+                    }
+                    return rows.map((week, idx) => (
+                      <Tr key={idx}>
+                        {week.map((day, j) => (
+                          <Td key={j} h="80px" verticalAlign="top">
+                            {Array.isArray(day) ? (
+                              <>
+                                <Text fontSize="xs" mb={1}>
+                                  {idx * 7 + j + 1 -
+                                    (week[0] === null ? j : 0)}
+                                </Text>
+                                {day.map((t) => (
+                                  <Text key={t.id} fontSize="xs">
+                                    {t.title}
+                                  </Text>
+                                ))}
+                              </>
+                            ) : null}
+                          </Td>
+                        ))}
+                      </Tr>
+                    ));
+                  })()}
+                </Tbody>
+              </Table>
+            </Box>
+          </TabPanel>
+          <TabPanel>
+            <Table variant="simple">
+              <Thead>
+                <Tr>
+                  <Th>Title</Th>
+                  <Th>Completed At</Th>
+                  <Th>Payment</Th>
+                  <Th>Rating</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {completed.map((task) => (
+                  <Tr key={task.id}>
+                    <Td>{task.title}</Td>
+                    <Td>{
+                      task.completedAt
+                        ? new Date(task.completedAt).toLocaleDateString()
+                        : ""
+                    }</Td>
+                    <Td>${task.payment}</Td>
+                    <Td>{task.rating ?? "-"}</Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+
+      <Modal isOpen={isOpen} onClose={onClose} isCentered>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Reschedule Task</ModalHeader>
+          <ModalBody>
+            <Input
+              type="date"
+              value={newDate}
+              onChange={(e) => setNewDate(e.target.value)}
+            />
+          </ModalBody>
+          <ModalFooter>
+            <Button mr={3} onClick={onClose}>
+              Cancel
+            </Button>
+            <Button colorScheme="brand" onClick={reschedule}>
+              Save
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </Box>
+  );
+}

--- a/app/api/experience/route.ts
+++ b/app/api/experience/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import prisma from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = parseInt(session.user.id);
+
+  const completedTasks = await prisma.task.findMany({
+    where: { taskerId: userId, status: "completed" },
+  });
+  const avgRating =
+    completedTasks.reduce((sum, t) => sum + (t.rating || 0), 0) /
+    (completedTasks.length || 1);
+
+  const activeOpportunities = await prisma.project.count({
+    where: { ownerId: userId },
+  });
+  const applications = await prisma.application.count({
+    where: { applicantId: userId },
+  });
+
+  return NextResponse.json({
+    participant: {
+      totalCompleted: completedTasks.length,
+      avgRating,
+    },
+    provider: {
+      activeOpportunities,
+      applications,
+    },
+  });
+}

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import prisma from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = parseInt(session.user.id);
+  const { id } = params;
+  const data = await req.json();
+  const taskId = parseInt(id);
+  const existing = await prisma.task.findFirst({
+    where: { id: taskId, taskerId: userId },
+  });
+  if (!existing) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  if (data.status === "completed") {
+    data.completedAt = new Date();
+  }
+  const task = await prisma.task.update({ where: { id: taskId }, data });
+  return NextResponse.json(task);
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = parseInt(session.user.id);
+  const taskId = parseInt(params.id);
+  const existing = await prisma.task.findFirst({
+    where: { id: taskId, taskerId: userId },
+  });
+  if (!existing) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  await prisma.task.delete({ where: { id: taskId } });
+  return NextResponse.json({});
+}

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import prisma from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = parseInt(session.user.id);
+  const tasks = await prisma.task.findMany({
+    where: { taskerId: userId },
+    orderBy: { deadline: "asc" },
+  });
+  return NextResponse.json(tasks);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = parseInt(session.user.id);
+  const data = await req.json();
+  const task = await prisma.task.create({
+    data: { ...data, taskerId: userId },
+  });
+  return NextResponse.json(task, { status: 201 });
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -20,6 +20,8 @@ export default function Sidebar() {
     { href: "/applications", label: "Applications" },
     { href: "/gigs", label: "Browse Gigs" },
     { href: "/gig-management", label: "Manage Gigs" },
+    { href: "/tasks", label: "Tasks" },
+    { href: "/experience", label: "Experience" },
   ];
 
   return (

--- a/lib/types/experience.ts
+++ b/lib/types/experience.ts
@@ -1,0 +1,10 @@
+export interface ExperienceSummary {
+  participant: {
+    totalCompleted: number;
+    avgRating: number;
+  };
+  provider: {
+    activeOpportunities: number;
+    applications: number;
+  };
+}

--- a/lib/types/task.ts
+++ b/lib/types/task.ts
@@ -1,0 +1,11 @@
+export interface Task {
+  id: number;
+  title: string;
+  instructions?: string;
+  payment: number;
+  deadline: string;
+  status: string;
+  reschedulable: boolean;
+  rating?: number;
+  completedAt?: string;
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -187,3 +187,30 @@ model Interview {
   notes          String?
   createdAt      DateTime  @default(now())
 }
+
+model Task {
+  id            Int      @id @default(autoincrement())
+  title         String
+  instructions  String?
+  payment       Float    @default(0)
+  deadline      DateTime
+  status        String   @default("active")
+  reschedulable Boolean  @default(true)
+  tasker        User     @relation(fields: [taskerId], references: [id])
+  taskerId      Int
+  rating        Float?
+  completedAt   DateTime?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+}
+
+model Experience {
+  id        Int      @id @default(autoincrement())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    Int
+  projects  Int      @default(0)
+  reviews   Int      @default(0)
+  skills    Int      @default(0)
+  createdAt DateTime @default(now())
+}
+

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -133,6 +133,35 @@ async function main() {
       ],
       skipDuplicates: true,
     });
+
+    await prisma.task.createMany({
+      data: [
+        {
+          title: 'Update Landing Page',
+          instructions: 'Revise hero section copy',
+          payment: 150,
+          deadline: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+          taskerId: admin.id,
+        },
+        {
+          title: 'Customer Research Calls',
+          instructions: 'Schedule and conduct 5 interviews',
+          payment: 300,
+          deadline: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000),
+          taskerId: admin.id,
+        },
+      ],
+      skipDuplicates: true,
+    });
+
+    await prisma.experience.create({
+      data: {
+        userId: admin.id,
+        projects: 2,
+        reviews: 5,
+        skills: 8,
+      },
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- add Task and Experience models with seed data
- build task schedule management page for taskers
- implement combined experience dashboard with stats and gig recommendations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68958d2c993c83209d5f705b8188fdaf