### PR TITLE
Add opportunity management and search pages

### DIFF
--- a/app/(dashboard)/opportunities/[id]/page.module.css
+++ b/app/(dashboard)/opportunities/[id]/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  padding: 1rem;
+}

--- a/app/(dashboard)/opportunities/[id]/page.tsx
+++ b/app/(dashboard)/opportunities/[id]/page.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import {
+  Box,
+  Heading,
+  Text,
+  Badge,
+  Button,
+  Spinner,
+  VStack,
+} from "@chakra-ui/react";
+import api from "@/lib/api";
+import { Opportunity } from "@/lib/types/opportunity";
+import styles from "./page.module.css";
+
+export default function OpportunityDetailPage() {
+  const params = useParams<{ id: string }>();
+  const id = Number(params.id);
+  const [opportunity, setOpportunity] = useState<Opportunity | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [applyLoading, setApplyLoading] = useState(false);
+  const [applied, setApplied] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await api.get<Opportunity>(`/opportunities/${id}`);
+        setOpportunity(data);
+      } catch (err: any) {
+        setError(err.message || "Failed to load opportunity");
+      } finally {
+        setLoading(false);
+      }
+    };
+    if (id) {
+      load();
+    }
+  }, [id]);
+
+  const apply = async () => {
+    setApplyLoading(true);
+    try {
+      await api.post(`/opportunities/${id}/apply`, {});
+      setApplied(true);
+    } catch (err: any) {
+      setError(err.message || "Failed to apply");
+    } finally {
+      setApplyLoading(false);
+    }
+  };
+
+  if (loading) return <Spinner />;
+  if (error) return <Text color="red.500">{error}</Text>;
+  if (!opportunity) return null;
+
+  return (
+    <Box className={styles.container}>
+      <VStack align="start" spacing={4}>
+        <Heading>{opportunity.title}</Heading>
+        <Badge alignSelf="flex-start">{opportunity.status}</Badge>
+        {typeof opportunity.compensation === "number" && (
+          <Text fontWeight="bold">${opportunity.compensation}</Text>
+        )}
+        <Text>{opportunity.description}</Text>
+        {!applied ? (
+          <Button colorScheme="brand" onClick={apply} isLoading={applyLoading}>
+            Apply Now
+          </Button>
+        ) : (
+          <Text color="green.500">Application submitted</Text>
+        )}
+      </VStack>
+    </Box>
+  );
+}

--- a/app/(dashboard)/opportunities/page.module.css
+++ b/app/(dashboard)/opportunities/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  padding: 1rem;
+}

--- a/app/(dashboard)/opportunities/page.tsx
+++ b/app/(dashboard)/opportunities/page.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Select,
+  SimpleGrid,
+  VStack,
+  HStack,
+  Spinner,
+  Text,
+} from "@chakra-ui/react";
+import api from "@/lib/api";
+import { Opportunity } from "@/lib/types/opportunity";
+import OpportunityCard from "@/components/OpportunityCard";
+import styles from "./page.module.css";
+
+export default function OpportunityBrowsePage() {
+  const [search, setSearch] = useState("");
+  const [category, setCategory] = useState("");
+  const [status, setStatus] = useState("");
+  const [opportunities, setOpportunities] = useState<Opportunity[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const load = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const params = new URLSearchParams();
+      if (search) params.set("search", search);
+      if (category) params.set("category", category);
+      if (status) params.set("status", status);
+      const data = await api.get<Opportunity[]>(`/opportunities?${params.toString()}`);
+      setOpportunities(data);
+    } catch (err: any) {
+      setError(err.message || "Failed to load opportunities");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <Box className={styles.container}>
+      <VStack as="form" spacing={4} align="stretch" onSubmit={(e) => e.preventDefault()}>
+        <HStack spacing={4} flexWrap="wrap">
+          <FormControl maxW="300px">
+            <FormLabel>Search</FormLabel>
+            <Input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search opportunities" />
+          </FormControl>
+          <FormControl maxW="200px">
+            <FormLabel>Category</FormLabel>
+            <Input value={category} onChange={(e) => setCategory(e.target.value)} />
+          </FormControl>
+          <FormControl maxW="200px">
+            <FormLabel>Status</FormLabel>
+            <Select value={status} onChange={(e) => setStatus(e.target.value)}>
+              <option value="">All</option>
+              <option value="open">Open</option>
+              <option value="in_progress">In Progress</option>
+              <option value="completed">Completed</option>
+            </Select>
+          </FormControl>
+          <Button colorScheme="brand" alignSelf="flex-end" onClick={load}>
+            Apply
+          </Button>
+        </HStack>
+      </VStack>
+      {error && (
+        <Text color="red.500" mt={4}>
+          {error}
+        </Text>
+      )}
+      {loading ? (
+        <Spinner mt={8} />
+      ) : (
+        <SimpleGrid columns={{ base: 1, sm: 2, md: 3 }} spacing={4} mt={6}>
+          {opportunities.map((opp) => (
+            <OpportunityCard key={opp.id} opportunity={opp} />
+          ))}
+        </SimpleGrid>
+      )}
+    </Box>
+  );
+}

--- a/app/(dashboard)/opportunity-management/page.module.css
+++ b/app/(dashboard)/opportunity-management/page.module.css
@@ -1,0 +1,3 @@
+.container {
+  padding: 1rem;
+}

--- a/app/(dashboard)/opportunity-management/page.tsx
+++ b/app/(dashboard)/opportunity-management/page.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  NumberInput,
+  NumberInputField,
+  Button,
+  SimpleGrid,
+  Spinner,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import api from "@/lib/api";
+import { Opportunity } from "@/lib/types/opportunity";
+import OpportunityCard from "@/components/OpportunityCard";
+import styles from "./page.module.css";
+
+export default function OpportunityManagementPage() {
+  const [myOpps, setMyOpps] = useState<Opportunity[]>([]);
+  const [applications, setApplications] = useState<Opportunity[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [form, setForm] = useState({
+    title: "",
+    description: "",
+    category: "",
+    location: "",
+    skills: "",
+    compensation: "",
+  });
+
+  const load = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const [provider, participant] = await Promise.all([
+        api.get<Opportunity[]>("/opportunities?mine=provider"),
+        api.get<Opportunity[]>("/opportunities?mine=participant"),
+      ]);
+      setMyOpps(provider);
+      setApplications(participant);
+    } catch (err: any) {
+      setError(err.message || "Failed to load opportunities");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const create = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      await api.post("/opportunities", {
+        title: form.title,
+        description: form.description,
+        category: form.category || undefined,
+        location: form.location || undefined,
+        skills: form.skills || undefined,
+        compensation: form.compensation ? Number(form.compensation) : undefined,
+      });
+      setForm({ title: "", description: "", category: "", location: "", skills: "", compensation: "" });
+      await load();
+    } catch (err: any) {
+      setError(err.message || "Failed to create opportunity");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box className={styles.container}>
+      {error && (
+        <Text color="red.500" mb={4}>
+          {error}
+        </Text>
+      )}
+      <Tabs variant="enclosed">
+        <TabList>
+          <Tab>My Opportunities</Tab>
+          <Tab>Applications</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <VStack as="form" spacing={4} align="stretch" maxW="600px" onSubmit={(e) => e.preventDefault()}>
+              <FormControl>
+                <FormLabel>Title</FormLabel>
+                <Input value={form.title} onChange={(e) => setForm({ ...form, title: e.target.value })} />
+              </FormControl>
+              <FormControl>
+                <FormLabel>Description</FormLabel>
+                <Textarea value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })} />
+              </FormControl>
+              <FormControl>
+                <FormLabel>Category</FormLabel>
+                <Input value={form.category} onChange={(e) => setForm({ ...form, category: e.target.value })} />
+              </FormControl>
+              <FormControl>
+                <FormLabel>Location</FormLabel>
+                <Input value={form.location} onChange={(e) => setForm({ ...form, location: e.target.value })} />
+              </FormControl>
+              <FormControl>
+                <FormLabel>Skills</FormLabel>
+                <Input value={form.skills} onChange={(e) => setForm({ ...form, skills: e.target.value })} />
+              </FormControl>
+              <FormControl>
+                <FormLabel>Compensation</FormLabel>
+                <NumberInput min={0} value={form.compensation} onChange={(v) => setForm({ ...form, compensation: v })}>
+                  <NumberInputField />
+                </NumberInput>
+              </FormControl>
+              <Button colorScheme="brand" onClick={create} isLoading={loading} alignSelf="flex-start">
+                Create Opportunity
+              </Button>
+            </VStack>
+            <SimpleGrid columns={{ base: 1, sm: 2, md: 3 }} spacing={4} mt={8}>
+              {myOpps.map((opp) => (
+                <OpportunityCard key={opp.id} opportunity={opp} />
+              ))}
+            </SimpleGrid>
+          </TabPanel>
+          <TabPanel>
+            {loading ? (
+              <Spinner />
+            ) : (
+              <SimpleGrid columns={{ base: 1, sm: 2, md: 3 }} spacing={4}>
+                {applications.map((opp) => (
+                  <OpportunityCard key={opp.id} opportunity={opp} />
+                ))}
+              </SimpleGrid>
+            )}
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </Box>
+  );
+}

--- a/app/api/opportunities/[id]/apply/route.ts
+++ b/app/api/opportunities/[id]/apply/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { applyToOpportunity } from "@/lib/services/opportunityService";
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  await applyToOpportunity(Number(params.id), Number(session.user.id));
+  return NextResponse.json({ success: true }, { status: 201 });
+}

--- a/app/api/opportunities/[id]/route.ts
+++ b/app/api/opportunities/[id]/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import {
+  getOpportunity,
+  updateOpportunity,
+  deleteOpportunity,
+} from "@/lib/services/opportunityService";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const id = Number(params.id);
+  const opportunity = await getOpportunity(id);
+  if (!opportunity) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(opportunity);
+}
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  const providerId = session?.user?.id ? Number(session.user.id) : undefined;
+  if (!providerId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const id = Number(params.id);
+  const existing = await getOpportunity(id);
+  if (!existing || existing.providerId !== providerId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const data = await req.json();
+  const updated = await updateOpportunity(id, data);
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  const providerId = session?.user?.id ? Number(session.user.id) : undefined;
+  if (!providerId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const id = Number(params.id);
+  const existing = await getOpportunity(id);
+  if (!existing || existing.providerId !== providerId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  await deleteOpportunity(id);
+  return NextResponse.json({ success: true });
+}

--- a/app/api/opportunities/route.ts
+++ b/app/api/opportunities/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import {
+  getOpportunities,
+  createOpportunity,
+} from "@/lib/services/opportunityService";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const session = await getServerSession(authOptions);
+  const search = searchParams.get("search") || undefined;
+  const category = searchParams.get("category") || undefined;
+  const status = searchParams.get("status") || undefined;
+  const mine = searchParams.get("mine");
+
+  if (mine === "provider") {
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const opportunities = await getOpportunities({
+      providerId: Number(session.user.id),
+      status,
+    });
+    return NextResponse.json(opportunities);
+  }
+
+  if (mine === "participant") {
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const opportunities = await getOpportunities({
+      participantId: Number(session.user.id),
+      status,
+    });
+    return NextResponse.json(opportunities);
+  }
+
+  const opportunities = await getOpportunities({ search, category, status });
+  return NextResponse.json(opportunities);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  const providerId = session?.user?.id ? Number(session.user.id) : undefined;
+  if (!providerId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const {
+    title,
+    description,
+    category,
+    location,
+    skills,
+    compensation,
+    status,
+  } = await req.json();
+  if (!title || !description) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+  }
+  const opportunity = await createOpportunity({
+    title,
+    description,
+    category,
+    location,
+    skills,
+    compensation,
+    status,
+    providerId,
+  });
+  return NextResponse.json(opportunity, { status: 201 });
+}

--- a/components/OpportunityCard.module.css
+++ b/components/OpportunityCard.module.css
@@ -1,0 +1,6 @@
+.card {
+  transition: box-shadow 0.2s ease-in-out;
+}
+.card:hover {
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
+}

--- a/components/OpportunityCard.tsx
+++ b/components/OpportunityCard.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Box, Heading, Text, Badge, VStack } from "@chakra-ui/react";
+import Link from "next/link";
+import { Opportunity } from "@/lib/types/opportunity";
+import styles from "./OpportunityCard.module.css";
+
+interface Props {
+  opportunity: Opportunity;
+}
+
+export default function OpportunityCard({ opportunity }: Props) {
+  const statusColor =
+    opportunity.status === "open"
+      ? "green"
+      : opportunity.status === "in_progress"
+      ? "yellow"
+      : "gray";
+  return (
+    <Box
+      as={Link}
+      href={`/opportunities/${opportunity.id}`}
+      borderWidth="1px"
+      borderRadius="md"
+      p={4}
+      className={styles.card}
+      _hover={{ shadow: "md" }}
+    >
+      <VStack align="start" spacing={2}>
+        <Heading size="md">{opportunity.title}</Heading>
+        <Text noOfLines={2}>{opportunity.description}</Text>
+        {typeof opportunity.compensation === "number" && (
+          <Text fontWeight="bold">${opportunity.compensation}</Text>
+        )}
+        <Badge colorScheme={statusColor}>{opportunity.status}</Badge>
+        {opportunity.applicationStatus && (
+          <Badge colorScheme="blue">{opportunity.applicationStatus}</Badge>
+        )}
+      </VStack>
+    </Box>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -20,6 +20,8 @@ export default function Sidebar() {
     { href: "/applications", label: "Applications" },
     { href: "/gigs", label: "Browse Gigs" },
     { href: "/gig-management", label: "Manage Gigs" },
+    { href: "/opportunities", label: "Browse Opportunities" },
+    { href: "/opportunity-management", label: "Manage Opportunities" },
   ];
 
   return (

--- a/lib/services/opportunityService.ts
+++ b/lib/services/opportunityService.ts
@@ -1,0 +1,87 @@
+import prisma from "@/lib/prisma";
+import type { Prisma } from "@prisma/client";
+
+export interface OpportunityFilters {
+  search?: string;
+  category?: string;
+  status?: string;
+  providerId?: number;
+  participantId?: number;
+}
+
+export async function getOpportunities(filters: OpportunityFilters = {}) {
+  const { search, category, status, providerId, participantId } = filters;
+  if (participantId) {
+    const applications = await prisma.opportunityApplication.findMany({
+      where: {
+        applicantId: participantId,
+        ...(status ? { status } : {}),
+      },
+      include: { opportunity: true },
+    });
+    return applications.map((a) => ({
+      ...a.opportunity,
+      applicationStatus: a.status,
+      applicationId: a.id,
+    }));
+  }
+
+  return prisma.opportunity.findMany({
+    where: {
+      ...(search ? { title: { contains: search, mode: "insensitive" } } : {}),
+      ...(category ? { category } : {}),
+      ...(status ? { status } : {}),
+      ...(providerId ? { providerId } : {}),
+    },
+    include: {
+      provider: { select: { id: true, name: true, image: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+export interface CreateOpportunityData {
+  title: string;
+  description: string;
+  category?: string;
+  location?: string;
+  skills?: string;
+  compensation?: number;
+  status?: string;
+  providerId: number;
+}
+
+export async function createOpportunity(data: CreateOpportunityData) {
+  return prisma.opportunity.create({ data });
+}
+
+export async function getOpportunity(id: number) {
+  return prisma.opportunity.findUnique({
+    where: { id },
+    include: {
+      provider: { select: { id: true, name: true, image: true } },
+      applications: {
+        include: {
+          applicant: { select: { id: true, name: true, image: true } },
+        },
+      },
+    },
+  });
+}
+
+export async function updateOpportunity(
+  id: number,
+  data: Partial<CreateOpportunityData> & { status?: string }
+) {
+  return prisma.opportunity.update({ where: { id }, data });
+}
+
+export async function deleteOpportunity(id: number) {
+  return prisma.opportunity.delete({ where: { id } });
+}
+
+export async function applyToOpportunity(opportunityId: number, applicantId: number) {
+  return prisma.opportunityApplication.create({
+    data: { opportunityId, applicantId },
+  });
+}

--- a/lib/types/opportunity.ts
+++ b/lib/types/opportunity.ts
@@ -1,0 +1,13 @@
+export interface Opportunity {
+  id: number;
+  title: string;
+  description: string;
+  category?: string;
+  location?: string;
+  skills?: string;
+  compensation?: number;
+  status: string;
+  providerId: number;
+  provider?: { id: number; name: string; image?: string };
+  applicationStatus?: string;
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,8 @@ model User {
   chatParticipants ChatParticipant[]
   messages         Message[]
   gigs             Gig[]
+  providedOpportunities Opportunity[] @relation("OpportunityProvider")
+  opportunityApplications OpportunityApplication[] @relation("OpportunityApplicant")
 }
 
 model Testimonial {
@@ -186,4 +188,29 @@ model Interview {
   status         String    @default("scheduled")
   notes          String?
   createdAt      DateTime  @default(now())
+}
+
+model Opportunity {
+  id           Int      @id @default(autoincrement())
+  title        String
+  description  String
+  category     String?
+  location     String?
+  skills       String?
+  compensation Int?
+  status       String   @default("open")
+  provider     User     @relation("OpportunityProvider", fields: [providerId], references: [id])
+  providerId   Int
+  applications OpportunityApplication[]
+  createdAt    DateTime @default(now())
+}
+
+model OpportunityApplication {
+  id            Int         @id @default(autoincrement())
+  opportunity   Opportunity @relation(fields: [opportunityId], references: [id])
+  opportunityId Int
+  applicant     User        @relation("OpportunityApplicant", fields: [applicantId], references: [id])
+  applicantId   Int
+  status        String      @default("pending")
+  createdAt     DateTime    @default(now())
 }


### PR DESCRIPTION
## Summary
- add Prisma models for opportunities and participant applications
- implement REST API for listing, creating, and applying to opportunities
- build Chakra UI pages for browsing and managing opportunities, plus sidebar navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68958d3a8df88320a054221ad40971a8