### PR TITLE
Add NextAuth API route

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };


### PR DESCRIPTION
## Summary
- add NextAuth API route to enable authentication endpoints

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897d6bfc1b0832093e9c7dbb4224894