### PR TITLE
fix: configure NextAuth credential auth

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,65 @@
 import type { NextAuthOptions } from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
+import GoogleProvider from "next-auth/providers/google";
+import LinkedInProvider from "next-auth/providers/linkedin";
+import { PrismaAdapter } from "@next-auth/prisma-adapter";
+import prisma from "./prisma";
+import { compare } from "bcryptjs";
+
+const providers = [
+  CredentialsProvider({
+    name: "Credentials",
+    credentials: {
+      email: { label: "Email", type: "email" },
+      password: { label: "Password", type: "password" },
+    },
+    async authorize(credentials) {
+      if (!credentials?.email || !credentials.password) {
+        return null;
+      }
+      const user = await prisma.user.findUnique({
+        where: { email: credentials.email },
+      });
+      if (!user) return null;
+      const isValid = await compare(credentials.password, user.password);
+      if (!isValid) return null;
+      return {
+        id: String(user.id),
+        email: user.email,
+        name: user.name ?? undefined,
+      };
+    },
+  }),
+];
+
+if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+  providers.push(
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    })
+  );
+}
+
+if (process.env.LINKEDIN_CLIENT_ID && process.env.LINKEDIN_CLIENT_SECRET) {
+  providers.push(
+    LinkedInProvider({
+      clientId: process.env.LINKEDIN_CLIENT_ID,
+      clientSecret: process.env.LINKEDIN_CLIENT_SECRET,
+    })
+  );
+}
 
 export const authOptions: NextAuthOptions = {
-  providers: [],
+  adapter: PrismaAdapter(prisma),
+  session: { strategy: "jwt" },
+  providers,
+  callbacks: {
+    async session({ session, token }) {
+      if (session.user && token.sub) {
+        session.user.id = token.sub;
+      }
+      return session;
+    },
+  },
 };


### PR DESCRIPTION
## Summary
- set up NextAuth with Prisma adapter and credential login
- conditionally enable Google and LinkedIn OAuth providers
- include user id in session callback

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897d888e8fc8320af20bd21c26d3754