### PR TITLE
Restore sidebar navigation in root layout

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,13 +1,11 @@
 "use client";
 
 import { Box } from "@chakra-ui/react";
-import Navbar from "@/components/Navbar";
 import LiveFeed from "@/components/LiveFeed";
 
 export default function DashboardPage() {
   return (
     <Box bg="slate.50" minH="100vh">
-      <Navbar />
       <LiveFeed />
     </Box>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { Providers } from "./providers";
 import { Geist, Geist_Mono } from "next/font/google";
+import Navbar from "@/components/Navbar";
+import Sidebar from "@/components/Sidebar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -23,7 +25,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <Providers>{children}</Providers>
+        <Providers>
+          <div style={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}>
+            <Navbar />
+            <div style={{ display: "flex", flex: 1 }}>
+              <Sidebar />
+              <main style={{ flex: 1 }}>{children}</main>
+            </div>
+          </div>
+        </Providers>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Add Navbar and Sidebar to root layout so navigation appears on all pages
- Simplify Dashboard page to rely on global layout's navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897f961cff48320b90d0912796131af