### PR TITLE
feat: enhance landing and feed design

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -35,6 +35,61 @@
   padding: 1rem;
 }
 
+.nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.25rem;
+  text-decoration: none;
+  color: var(--color-dark);
+}
+
+.navLinks a {
+  margin-left: 1rem;
+  text-decoration: none;
+  color: var(--color-dark);
+  transition: color 0.2s ease;
+}
+
+.navLinks a:hover {
+  color: var(--color-primary);
+}
+
+.ctaButton {
+  margin-top: 1rem;
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  background: var(--color-primary);
+  color: var(--color-light);
+  text-decoration: none;
+}
+
+.features {
+  display: grid;
+  gap: 2rem;
+  padding: 4rem 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.feature {
+  background: var(--color-light);
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+  padding: 1.5rem;
+  text-align: center;
+  transition: transform 0.2s ease;
+}
+
+.feature:hover {
+  transform: translateY(-4px);
+}
+
 
 .pricingCard {
   transition: transform 0.2s ease;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,51 @@
-import { redirect } from "next/navigation";
+import Link from "next/link";
+import Image from "next/image";
+import styles from "./page.module.css";
 
 export default function Home() {
-  redirect("/dashboard");
-  return null;
+  return (
+    <main>
+      <header className={styles.header}>
+        <nav className={styles.nav}>
+          <Link href="/" className={styles.logo}>
+            Orbas
+          </Link>
+          <div className={styles.navLinks}>
+            <Link href="/signup">Sign Up</Link>
+            <Link href="/api/auth/signin">Log In</Link>
+          </div>
+        </nav>
+      </header>
+      <section className={styles.hero}>
+        <Image
+          src="https://source.unsplash.com/random/1600x900?career"
+          alt="Collaborate"
+          fill
+          sizes="100vw"
+          className={styles.heroImage}
+        />
+        <div className={styles.heroOverlay}>
+          <h1>Welcome to Orbas</h1>
+          <p>Connect, collaborate and grow with a global community.</p>
+          <Link href="/signup" className={styles.ctaButton}>
+            Get Started
+          </Link>
+        </div>
+      </section>
+      <section className={styles.features}>
+        <div className={styles.feature}>
+          <h3>Connect</h3>
+          <p>Build your network with like-minded professionals.</p>
+        </div>
+        <div className={styles.feature}>
+          <h3>Create</h3>
+          <p>Showcase your projects and skills with ease.</p>
+        </div>
+        <div className={styles.feature}>
+          <h3>Grow</h3>
+          <p>Discover new opportunities tailored for you.</p>
+        </div>
+      </section>
+    </main>
+  );
 }

--- a/components/LiveFeed.module.css
+++ b/components/LiveFeed.module.css
@@ -5,6 +5,26 @@
   padding: 1rem 0 3rem;
 }
 
+.stories {
+  width: 100%;
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+}
+
+.story {
+  flex: 0 0 auto;
+  text-align: center;
+}
+
+.storyAvatar {
+  border: 2px solid var(--color-primary);
+  transition: transform 0.2s ease;
+}
+
+.storyAvatar:hover {
+  transform: scale(1.05);
+}
+
 .post {
   width: 100%;
   background: var(--color-light);
@@ -12,6 +32,11 @@
   border-radius: 8px;
   overflow: hidden;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+  transition: box-shadow 0.2s ease;
+}
+
+.post:hover {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
 }
 
 .postHeader {

--- a/components/LiveFeed.tsx
+++ b/components/LiveFeed.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Avatar, Box, HStack, Image, Text, VStack } from "@chakra-ui/react";
+import {
+  Avatar,
+  Box,
+  HStack,
+  Image,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { useEffect, useRef, useState } from "react";
 import styles from "./LiveFeed.module.css";
 
 interface Post {
@@ -12,7 +20,7 @@ interface Post {
   likes: number;
 }
 
-const posts: Post[] = [
+const initialPosts: Post[] = [
   {
     id: 1,
     user: "Demo User",
@@ -39,9 +47,55 @@ const posts: Post[] = [
   },
 ];
 
+const stories = [
+  { id: 1, name: "Alice", avatar: "/next.svg" },
+  { id: 2, name: "Bob", avatar: "/next.svg" },
+  { id: 3, name: "Cleo", avatar: "/next.svg" },
+  { id: 4, name: "Dan", avatar: "/next.svg" },
+  { id: 5, name: "Eve", avatar: "/next.svg" },
+];
+
 export default function LiveFeed() {
+  const [posts, setPosts] = useState<Post[]>(initialPosts);
+  const loader = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        setPosts((prev) => [
+          ...prev,
+          ...initialPosts.map((p, i) => ({ ...p, id: prev.length + i + 1 })),
+        ]);
+      }
+    });
+
+    const current = loader.current;
+    if (current) {
+      observer.observe(current);
+    }
+
+    return () => {
+      if (current) {
+        observer.unobserve(current);
+      }
+    };
+  }, []);
+
   return (
     <VStack spacing={6} className={styles.feed}>
+      <HStack spacing={3} className={styles.stories}>
+        {stories.map((story) => (
+          <VStack key={story.id} className={styles.story}>
+            <Avatar
+              src={story.avatar}
+              name={story.name}
+              size="md"
+              className={styles.storyAvatar}
+            />
+            <Text fontSize="sm">{story.name}</Text>
+          </VStack>
+        ))}
+      </HStack>
       {posts.map((post) => (
         <Box key={post.id} className={styles.post}>
           <HStack className={styles.postHeader} spacing={3}>
@@ -57,6 +111,7 @@ export default function LiveFeed() {
           </Box>
         </Box>
       ))}
+      <div ref={loader} />
     </VStack>
   );
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "source.unsplash.com",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- build a proper landing page with a hero and feature cards
- add story bar, shadowed cards and infinite scrolling to the live feed
- allow Unsplash images through Next.js remote patterns

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897f8e281f4832091916631732cf2cc