### PR TITLE
feat: enhance profile page with dashboard cards

### DIFF
--- a/app/profile/page.module.css
+++ b/app/profile/page.module.css
@@ -1,8 +1,5 @@
 .container {
-  max-width: 400px;
+  max-width: 960px;
   margin: 2rem auto;
-  background: white;
-  padding: 2rem;
-  border-radius: 0.5rem;
-  box-shadow: 0 0 10px rgba(0,0,0,0.05);
+  padding: 0 1rem;
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,9 +1,19 @@
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
-import { Avatar, Box, Heading, Text, Stack, Button } from "@chakra-ui/react";
+import {
+  Avatar,
+  Box,
+  Heading,
+  Text,
+  Stack,
+  Button,
+  SimpleGrid,
+} from "@chakra-ui/react";
 import Link from "next/link";
 import styles from "./page.module.css";
 import { authOptions } from "../../lib/auth";
+import DashboardCard from "../../components/DashboardCard";
+import StatWidget from "../../components/StatWidget";
 
 export default async function ProfilePage() {
   const session = await getServerSession(authOptions);
@@ -11,14 +21,41 @@ export default async function ProfilePage() {
   const { user } = session;
   return (
     <Box className={styles.container}>
-      <Stack spacing={4} align="center">
-        <Avatar name={user?.name || "User"} src={user?.image || undefined} size="xl" />
-        <Heading size="md">{user?.name}</Heading>
-        <Text>{user?.email}</Text>
-        <Button as={Link} href="/profile/edit" colorScheme="brand">
-          Edit Profile
-        </Button>
-      </Stack>
+      <SimpleGrid columns={{ base: 1, md: 2 }} spacing={6}>
+        <DashboardCard title="Profile">
+          <Stack spacing={4} align="center">
+            <Avatar
+              name={user?.name || "User"}
+              src={user?.image || undefined}
+              size="xl"
+            />
+            <Heading size="md">{user?.name}</Heading>
+            <Text>{user?.email}</Text>
+          </Stack>
+        </DashboardCard>
+        <DashboardCard title="Stats">
+          <SimpleGrid columns={3} spacing={4}>
+            <StatWidget label="Posts" value={0} />
+            <StatWidget label="Followers" value={0} />
+            <StatWidget label="Following" value={0} />
+          </SimpleGrid>
+        </DashboardCard>
+        <DashboardCard title="Actions">
+          <Stack spacing={3}>
+            <Button
+              as={Link}
+              href="/profile/edit"
+              colorScheme="brand"
+              width="full"
+            >
+              Edit Profile
+            </Button>
+            <Button variant="outline" colorScheme="brand" width="full">
+              Settings
+            </Button>
+          </Stack>
+        </DashboardCard>
+      </SimpleGrid>
     </Box>
   );
 }

--- a/components/DashboardCard.module.css
+++ b/components/DashboardCard.module.css
@@ -1,3 +1,9 @@
 .card {
   width: 100%;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
 }


### PR DESCRIPTION
## Summary
- redesign profile page as interactive dashboard with profile, stats, and action cards
- widen profile layout and introduce responsive grid
- add hover elevation effect to dashboard cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897fde9437c8320ad63a3e0ae8f2fe1