### PR TITLE
Add placeholder pages for menu sections

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { Box, Heading, Text } from "@chakra-ui/react";
+
+export default function PlaceholderPage({ params }: { params: { slug: string[] } }) {
+  const path = `/${params.slug.join("/")}`;
+  return (
+    <Box p={8} textAlign="center">
+      <Heading size="lg" mb={4}>
+        Page Under Construction
+      </Heading>
+      <Text>The page <strong>{path}</strong> is coming soon.</Text>
+    </Box>
+  );
+}

--- a/app/applications/page.tsx
+++ b/app/applications/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Applications" />;
+}

--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Billing" />;
+}

--- a/app/connections/page.tsx
+++ b/app/connections/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Connections" />;
+}

--- a/app/contracts/page.tsx
+++ b/app/contracts/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Contracts" />;
+}

--- a/app/course-management/page.tsx
+++ b/app/course-management/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Course Management" />;
+}

--- a/app/education/page.tsx
+++ b/app/education/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Education" />;
+}

--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Feed" />;
+}

--- a/app/gig-management/page.tsx
+++ b/app/gig-management/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Gig Management" />;
+}

--- a/app/gigs/page.tsx
+++ b/app/gigs/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Gigs" />;
+}

--- a/app/interviews/page.tsx
+++ b/app/interviews/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Interviews" />;
+}

--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Jobs" />;
+}

--- a/app/messages/page.tsx
+++ b/app/messages/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Messages" />;
+}

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Notifications" />;
+}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Onboarding" />;
+}

--- a/app/opportunities/page.tsx
+++ b/app/opportunities/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Opportunities" />;
+}

--- a/app/opportunity-management/page.tsx
+++ b/app/opportunity-management/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Opportunity Management" />;
+}

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Progress" />;
+}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Search" />;
+}

--- a/app/service-management/page.tsx
+++ b/app/service-management/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Service Management" />;
+}

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Services" />;
+}

--- a/app/session-management/page.tsx
+++ b/app/session-management/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Session Management" />;
+}

--- a/app/sessions/page.tsx
+++ b/app/sessions/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Sessions" />;
+}

--- a/app/tasks/page.tsx
+++ b/app/tasks/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Tasks" />;
+}

--- a/app/volunteer/applications/page.tsx
+++ b/app/volunteer/applications/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Volunteer Applications" />;
+}

--- a/app/volunteer/opportunities/page.tsx
+++ b/app/volunteer/opportunities/page.tsx
@@ -1,0 +1,5 @@
+import UnderConstruction from "@/components/UnderConstruction";
+
+export default function Page() {
+  return <UnderConstruction title="Volunteer Opportunities" />;
+}

--- a/components/UnderConstruction.tsx
+++ b/components/UnderConstruction.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { Box, Heading, Text } from "@chakra-ui/react";
+
+export default function UnderConstruction({ title }: { title: string }) {
+  return (
+    <Box p={8} textAlign="center">
+      <Heading size="lg" mb={4}>
+        {title}
+      </Heading>
+      <Text>This page is under construction.</Text>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add shared `UnderConstruction` component
- create placeholder pages for each navigation route (feed, jobs, services, sessions, etc.) to avoid 404s

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897fe31f8f483209c14885f9181f8fb