### PR TITLE
Add fuzzy search engine and search page

### DIFF
--- a/app/api/features/route.ts
+++ b/app/api/features/route.ts
@@ -1,33 +1,6 @@
 import { NextResponse } from "next/server";
+import { features } from "@/lib/data";
 
 export async function GET() {
-  const features = [
-    {
-      id: 1,
-      title: "AI-Powered Matching",
-      description:
-        "Leverage machine learning to connect talent with the right opportunities faster.",
-      imageUrl:
-        "https://images.unsplash.com/photo-1551836022-4c4c79ecde33?w=800&auto=format&fit=crop",
-    },
-    {
-      id: 2,
-      title: "Unified Gig Management",
-      description:
-        "Track tasks, proposals, and payments from a single intuitive dashboard.",
-      imageUrl:
-        "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?w=800&auto=format&fit=crop",
-    },
-    {
-      id: 3,
-      title: "Real-Time Analytics",
-      description:
-        "Gain insight into performance with interactive charts and reports.",
-      imageUrl:
-        "https://images.unsplash.com/photo-1556157382-97eda2d62296?w=800&auto=format&fit=crop",
-    },
-  ];
-
   return NextResponse.json(features);
 }
-

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import { search } from "@/lib/search";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const q = searchParams.get("q") || "";
+  const results = search(q);
+  return NextResponse.json(results);
+}

--- a/app/api/solutions/route.ts
+++ b/app/api/solutions/route.ts
@@ -1,36 +1,6 @@
 import { NextResponse } from "next/server";
+import { solutions } from "@/lib/data";
 
 export async function GET() {
-  const solutions = [
-    {
-      id: 1,
-      title: "Recruitment Teams",
-      description:
-        "Source candidates, manage interviews, and collaborate with hiring managers in one workspace.",
-      imageUrl:
-        "https://images.unsplash.com/photo-1522071820081-009f0129c71c?w=800&auto=format&fit=crop",
-      ctaText: "Request Demo",
-    },
-    {
-      id: 2,
-      title: "Freelance Marketplaces",
-      description:
-        "Launch a gig marketplace complete with escrow, reviews, and dispute resolution.",
-      imageUrl:
-        "https://images.unsplash.com/photo-1504384308090-c894fdcc538d?w=800&auto=format&fit=crop",
-      ctaText: "Learn More",
-    },
-    {
-      id: 3,
-      title: "Enterprise Analytics",
-      description:
-        "Visualize workforce data to make informed decisions and drive productivity.",
-      imageUrl:
-        "https://images.unsplash.com/photo-1551434678-e076c223a692?w=800&auto=format&fit=crop",
-      ctaText: "Contact Sales",
-    },
-  ];
-
   return NextResponse.json(solutions);
 }
-

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Box, Heading, Text, VStack, Image } from "@chakra-ui/react";
+import { useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+import { search } from "@/lib/search";
+
+export default function SearchPage() {
+  const params = useSearchParams();
+  const q = params.get("q") || "";
+  const results = useMemo(() => search(q), [q]);
+
+  if (!q) {
+    return (
+      <Box p={6}>
+        <Heading mb={4}>Search</Heading>
+        <Text>Enter a term in the search bar to begin.</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box p={6}>
+      <Heading mb={4}>Search Results for &quot;{q}&quot;</Heading>
+      {results.length === 0 ? (
+        <Text>No results found.</Text>
+      ) : (
+        <VStack spacing={4} align="stretch">
+          {results.map((item) => (
+            <Box
+              key={`${item.type}-${item.id}`}
+              borderWidth="1px"
+              borderRadius="md"
+              p={4}
+            >
+              <Heading size="md" mb={2}>
+                {item.title}
+              </Heading>
+              <Text mb={2}>{item.description}</Text>
+              {item.imageUrl && (
+                <Image
+                  src={item.imageUrl}
+                  alt={item.title}
+                  maxH="200px"
+                  objectFit="cover"
+                />
+              )}
+            </Box>
+          ))}
+        </VStack>
+      )}
+    </Box>
+  );
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,0 +1,83 @@
+export interface Feature {
+  id: number;
+  title: string;
+  description: string;
+  imageUrl: string;
+  type: "feature";
+}
+
+export interface Solution {
+  id: number;
+  title: string;
+  description: string;
+  imageUrl: string;
+  ctaText: string;
+  type: "solution";
+}
+
+export type SearchItem = Feature | Solution;
+
+export const features: Feature[] = [
+  {
+    id: 1,
+    title: "AI-Powered Matching",
+    description:
+      "Leverage machine learning to connect talent with the right opportunities faster.",
+    imageUrl:
+      "https://images.unsplash.com/photo-1551836022-4c4c79ecde33?w=800&auto=format&fit=crop",
+    type: "feature",
+  },
+  {
+    id: 2,
+    title: "Unified Gig Management",
+    description:
+      "Track tasks, proposals, and payments from a single intuitive dashboard.",
+    imageUrl:
+      "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?w=800&auto=format&fit=crop",
+    type: "feature",
+  },
+  {
+    id: 3,
+    title: "Real-Time Analytics",
+    description:
+      "Gain insight into performance with interactive charts and reports.",
+    imageUrl:
+      "https://images.unsplash.com/photo-1556157382-97eda2d62296?w=800&auto=format&fit=crop",
+    type: "feature",
+  },
+];
+
+export const solutions: Solution[] = [
+  {
+    id: 1,
+    title: "Recruitment Teams",
+    description:
+      "Source candidates, manage interviews, and collaborate with hiring managers in one workspace.",
+    imageUrl:
+      "https://images.unsplash.com/photo-1522071820081-009f0129c71c?w=800&auto=format&fit=crop",
+    ctaText: "Request Demo",
+    type: "solution",
+  },
+  {
+    id: 2,
+    title: "Freelance Marketplaces",
+    description:
+      "Launch a gig marketplace complete with escrow, reviews, and dispute resolution.",
+    imageUrl:
+      "https://images.unsplash.com/photo-1504384308090-c894fdcc538d?w=800&auto=format&fit=crop",
+    ctaText: "Learn More",
+    type: "solution",
+  },
+  {
+    id: 3,
+    title: "Enterprise Analytics",
+    description:
+      "Visualize workforce data to make informed decisions and drive productivity.",
+    imageUrl:
+      "https://images.unsplash.com/photo-1551434678-e076c223a692?w=800&auto=format&fit=crop",
+    ctaText: "Contact Sales",
+    type: "solution",
+  },
+];
+
+export const searchItems: SearchItem[] = [...features, ...solutions];

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,0 +1,12 @@
+import Fuse from "fuse.js";
+import { searchItems, SearchItem } from "./data";
+
+const fuse = new Fuse<SearchItem>(searchItems, {
+  keys: ["title", "description"],
+  threshold: 0.3,
+});
+
+export function search(query: string): SearchItem[] {
+  if (!query) return [];
+  return fuse.search(query).map((r) => r.item);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@prisma/client": "^6.13.0",
         "bcryptjs": "^3.0.2",
         "framer-motion": "^11.0.3",
+        "fuse.js": "^7.1.0",
         "next": "15.4.5",
         "next-auth": "^4.24.11",
         "react": "19.1.0",
@@ -4519,6 +4520,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/get-intrinsic": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@prisma/client": "^6.13.0",
     "bcryptjs": "^3.0.2",
     "framer-motion": "^11.0.3",
+    "fuse.js": "^7.1.0",
     "next": "15.4.5",
     "next-auth": "^4.24.11",
     "react": "19.1.0",


### PR DESCRIPTION
## Summary
- integrate Fuse.js fuzzy search library
- centralize feature and solution data and expose search API
- build search results page wired to global navbar search

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897ffe93a94832090763c823019ad06