### PR TITLE
Improve navigation menu styling and add collapsible sidebar sections

### DIFF
--- a/components/Navbar.module.css
+++ b/components/Navbar.module.css
@@ -2,4 +2,18 @@
   font-family: 'Poppins', sans-serif;
   font-weight: 600;
   color: var(--color-primary);
+  font-size: 1.25rem;
+}
+
+.menuList {
+  font-family: 'Poppins', sans-serif;
+  border-radius: 0.5rem;
+}
+
+.menuItem {
+  font-size: 0.875rem;
+}
+
+.menuItem:hover {
+  background-color: rgba(65, 105, 225, 0.1);
 }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -53,27 +53,27 @@ export default function Navbar() {
         onChange={(e) => setTerm(e.target.value)}
         onKeyDown={handleKeyDown}
       />
-      <Menu>
+  <Menu>
         <MenuButton>
           <Avatar name={user.name} src={user.image} size="sm" />
         </MenuButton>
-        <MenuList>
-          <MenuItem as={Link} href="/profile">
+        <MenuList className={styles.menuList} py={2} shadow="md">
+          <MenuItem className={styles.menuItem} as={Link} href="/profile">
             Profile
           </MenuItem>
-          <MenuItem as={Link} href="/onboarding">
+          <MenuItem className={styles.menuItem} as={Link} href="/onboarding">
             Onboarding
           </MenuItem>
-          <MenuItem as={Link} href="/profile/edit">
+          <MenuItem className={styles.menuItem} as={Link} href="/profile/edit">
             Edit Profile
           </MenuItem>
-          <MenuItem as={Link} href="/billing">
+          <MenuItem className={styles.menuItem} as={Link} href="/billing">
             Billing
           </MenuItem>
-          <MenuItem as={Link} href="/services">
+          <MenuItem className={styles.menuItem} as={Link} href="/services">
             Services
           </MenuItem>
-          <MenuItem as={Link} href="/sessions">
+          <MenuItem className={styles.menuItem} as={Link} href="/sessions">
             Sessions
           </MenuItem>
         </MenuList>

--- a/components/Sidebar.module.css
+++ b/components/Sidebar.module.css
@@ -4,7 +4,8 @@
 }
 
 .section {
-  margin-top: 1rem;
+  margin-top: 0.5rem;
+  padding: 0.25rem 0;
 }
 
 .sectionTitle {
@@ -13,6 +14,13 @@
   color: var(--color-primary);
   text-transform: uppercase;
   padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  display: flex;
+  align-items: center;
+}
+
+.sectionTitle:hover {
+  background-color: rgba(65, 105, 225, 0.05);
 }
 
 .link {

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { VStack, Box, Text, Link as ChakraLink } from "@chakra-ui/react";
+import {
+  Accordion,
+  AccordionItem,
+  AccordionButton,
+  AccordionPanel,
+  AccordionIcon,
+  Box,
+  Link as ChakraLink,
+} from "@chakra-ui/react";
 import NextLink from "next/link";
 import { usePathname } from "next/navigation";
 import styles from "./Sidebar.module.css";
@@ -69,33 +77,43 @@ export default function Sidebar() {
   ];
 
   return (
-    <VStack
+    <Accordion
       as="nav"
       w={{ base: "full", md: "60" }}
       bg="white"
       h="calc(100vh - 64px)"
       p={4}
-      spacing={0}
-      align="stretch"
+      allowMultiple
+      className={styles.nav}
       borderRightWidth="1px"
       borderColor="gray.200"
-      className={styles.nav}
     >
       {sections.map((section) => (
-        <Box key={section.title} className={styles.section}>
-          <Text className={styles.sectionTitle}>{section.title}</Text>
-          {section.links.map((link) => (
-            <ChakraLink
-              key={link.href}
-              as={NextLink}
-              href={link.href}
-              className={`${styles.link} ${pathname === link.href ? styles.active : ""}`}
-            >
-              {link.label}
-            </ChakraLink>
-          ))}
-        </Box>
+        <AccordionItem key={section.title} border="none">
+          <h2>
+            <AccordionButton className={styles.sectionTitle}>
+              <Box flex="1" textAlign="left">
+                {section.title}
+              </Box>
+              <AccordionIcon />
+            </AccordionButton>
+          </h2>
+          <AccordionPanel className={styles.section}>
+            {section.links.map((link) => (
+              <ChakraLink
+                key={link.href}
+                as={NextLink}
+                href={link.href}
+                className={`${styles.link} ${
+                  pathname === link.href ? styles.active : ""
+                }`}
+              >
+                {link.label}
+              </ChakraLink>
+            ))}
+          </AccordionPanel>
+        </AccordionItem>
       ))}
-    </VStack>
+    </Accordion>
   );
 }


### PR DESCRIPTION
## Summary
- Polish navbar menu styling with consistent fonts and hover feedback
- Convert sidebar sections into accordion drawers for easier navigation by subject

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897ffd2cd40832096cf8b262f291e77