### PR TITLE
Implement Work section pages and navigation fix

### DIFF
--- a/app/applications/page.tsx
+++ b/app/applications/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Box, Heading, VStack } from "@chakra-ui/react";
+import ApplicationItem from "@/components/ApplicationItem";
+
+const applications = [
+  { id: 1, jobTitle: "Frontend Developer", applicantName: "Alice", status: "pending" },
+  { id: 2, jobTitle: "Backend Engineer", applicantName: "Bob", status: "interview" },
+];
+
+export default function ApplicationsPage() {
+  const handleStatusChange = (id: number, status: string) => {
+    console.log(`Application ${id} status changed to ${status}`);
+  };
+
+  const handleSchedule = (id: number) => {
+    console.log(`Schedule interview for application ${id}`);
+  };
+
+  return (
+    <Box p={4}>
+      <Heading size="md" mb={4}>
+        Applications
+      </Heading>
+      <VStack spacing={4} align="stretch">
+        {applications.map((app) => (
+          <ApplicationItem
+            key={app.id}
+            id={app.id}
+            jobTitle={app.jobTitle}
+            applicantName={app.applicantName}
+            status={app.status}
+            onStatusChange={(status) => handleStatusChange(app.id, status)}
+            onSchedule={() => handleSchedule(app.id)}
+          />
+        ))}
+      </VStack>
+    </Box>
+  );
+}
+

--- a/app/contracts/[id]/page.tsx
+++ b/app/contracts/[id]/page.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { Box, Heading, Text } from "@chakra-ui/react";
+
+export default function ContractDetailPage({ params }: { params: { id: string } }) {
+  return (
+    <Box p={4}>
+      <Heading size="md" mb={2}>
+        Contract {params.id}
+      </Heading>
+      <Text>Contract details will be available soon.</Text>
+    </Box>
+  );
+}
+

--- a/app/contracts/page.tsx
+++ b/app/contracts/page.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { Box, Heading, VStack } from "@chakra-ui/react";
+import ContractCard, { Contract } from "@/components/ContractCard";
+
+const contracts: Contract[] = [
+  {
+    id: 1,
+    title: "Web App Development",
+    status: "IN_PROGRESS",
+    totalValue: 5000,
+    milestones: [
+      { id: 1, title: "Design", amount: 1000, status: "PAID" },
+      { id: 2, title: "Development", amount: 3000, status: "APPROVED" },
+      { id: 3, title: "Launch", amount: 1000, status: "PENDING" },
+    ],
+  },
+];
+
+export default function ContractsPage() {
+  return (
+    <Box p={4}>
+      <Heading size="md" mb={4}>
+        Contracts
+      </Heading>
+      <VStack spacing={4} align="stretch">
+        {contracts.map((contract) => (
+          <ContractCard key={contract.id} contract={contract} />
+        ))}
+      </VStack>
+    </Box>
+  );
+}
+

--- a/app/gig-management/page.tsx
+++ b/app/gig-management/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Box, Heading, SimpleGrid } from "@chakra-ui/react";
+import GigCard from "@/components/GigCard";
+import { Gig } from "@/lib/types/gig";
+
+const myGigs: Gig[] = [
+  {
+    id: 1,
+    title: "Marketing Consultation",
+    price: 300,
+    category: "Marketing",
+    thumbnail: "https://source.unsplash.com/random/400x300?marketing",
+    rating: 5,
+    seller: { id: 1, name: "You", image: "/next.svg" },
+  },
+];
+
+export default function GigManagementPage() {
+  return (
+    <Box p={4}>
+      <Heading size="md" mb={4}>
+        Manage Gigs
+      </Heading>
+      <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={4}>
+        {myGigs.map((gig) => (
+          <GigCard key={gig.id} gig={gig} />
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}
+

--- a/app/gigs/[id]/page.tsx
+++ b/app/gigs/[id]/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { Box } from "@chakra-ui/react";
+import GigDetail from "@/components/GigDetail";
+import { GigDetails } from "@/lib/types/gig";
+
+export default function GigDetailPage({ params }: { params: { id: string } }) {
+  const gig: GigDetails = {
+    id: Number(params.id),
+    title: "Sample Gig",
+    price: 200,
+    description: "Detailed description coming soon.",
+    views: 0,
+    seller: { id: 1, name: "Jane Doe", image: "/next.svg" },
+    thumbnail: "https://source.unsplash.com/random/800x600?project",
+  };
+
+  return (
+    <Box p={4}>
+      <GigDetail gig={gig} />
+    </Box>
+  );
+}
+

--- a/app/gigs/page.tsx
+++ b/app/gigs/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Box, Heading, SimpleGrid } from "@chakra-ui/react";
+import GigCard from "@/components/GigCard";
+import { Gig } from "@/lib/types/gig";
+
+const gigs: Gig[] = [
+  {
+    id: 1,
+    title: "Logo Design",
+    price: 150,
+    category: "Design",
+    thumbnail: "https://source.unsplash.com/random/400x300?logo",
+    rating: 4,
+    seller: { id: 1, name: "Jane Doe", image: "/next.svg" },
+  },
+  {
+    id: 2,
+    title: "Full Website Build",
+    price: 1200,
+    category: "Development",
+    thumbnail: "https://source.unsplash.com/random/400x300?website",
+    rating: 5,
+    seller: { id: 2, name: "John Smith", image: "/next.svg" },
+  },
+];
+
+export default function GigsPage() {
+  return (
+    <Box p={4}>
+      <Heading size="md" mb={4}>
+        Browse Gigs
+      </Heading>
+      <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={4}>
+        {gigs.map((gig) => (
+          <GigCard key={gig.id} gig={gig} />
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}
+

--- a/app/interviews/page.tsx
+++ b/app/interviews/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { Box, Heading, VStack } from "@chakra-ui/react";
+import InterviewItem from "@/components/InterviewItem";
+
+const interviews = [
+  {
+    id: 1,
+    jobTitle: "Frontend Developer",
+    scheduledAt: new Date().toISOString(),
+    location: "Zoom",
+    link: "https://zoom.us/j/123456789",
+    status: "scheduled",
+  },
+  {
+    id: 2,
+    jobTitle: "Backend Engineer",
+    scheduledAt: new Date(Date.now() + 86400000).toISOString(),
+    status: "pending",
+  },
+];
+
+export default function InterviewsPage() {
+  return (
+    <Box p={4}>
+      <Heading size="md" mb={4}>
+        Interviews
+      </Heading>
+      <VStack spacing={4} align="stretch">
+        {interviews.map((interview) => (
+          <InterviewItem
+            key={interview.id}
+            jobTitle={interview.jobTitle}
+            scheduledAt={interview.scheduledAt}
+            location={interview.location}
+            link={interview.link}
+            status={interview.status}
+          />
+        ))}
+      </VStack>
+    </Box>
+  );
+}
+

--- a/app/jobs/[id]/page.tsx
+++ b/app/jobs/[id]/page.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { Box, Heading, Text } from "@chakra-ui/react";
+
+export default function JobDetailPage({ params }: { params: { id: string } }) {
+  return (
+    <Box p={4}>
+      <Heading size="md" mb={2}>
+        Job {params.id}
+      </Heading>
+      <Text>Job details coming soon.</Text>
+    </Box>
+  );
+}
+

--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { Box, Heading } from "@chakra-ui/react";
+import JobMatchList from "@/components/JobMatchList";
+
+const jobs = [
+  { id: 1, title: "Frontend Developer", company: "Tech Corp" },
+  { id: 2, title: "Backend Engineer", company: "Data Solutions" },
+  { id: 3, title: "Full Stack Developer", company: "Web Innovators" },
+];
+
+export default function JobsPage() {
+  return (
+    <Box p={4}>
+      <Heading size="md" mb={4}>
+        Jobs
+      </Heading>
+      <JobMatchList jobs={jobs} />
+    </Box>
+  );
+}
+

--- a/app/tasks/page.tsx
+++ b/app/tasks/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Box, Heading, VStack, HStack, Checkbox } from "@chakra-ui/react";
+
+interface Task {
+  id: number;
+  title: string;
+  completed: boolean;
+}
+
+const tasks: Task[] = [
+  { id: 1, title: "Update portfolio", completed: false },
+  { id: 2, title: "Submit proposal", completed: true },
+];
+
+export default function TasksPage() {
+  return (
+    <Box p={4}>
+      <Heading size="md" mb={4}>
+        Tasks
+      </Heading>
+      <VStack spacing={3} align="stretch">
+        {tasks.map((task) => (
+          <HStack
+            key={task.id}
+            p={3}
+            borderWidth="1px"
+            borderRadius="md"
+            bg="white"
+          >
+            <Checkbox isChecked={task.completed}>{task.title}</Checkbox>
+          </HStack>
+        ))}
+      </VStack>
+    </Box>
+  );
+}
+

--- a/components/ContractCard.tsx
+++ b/components/ContractCard.tsx
@@ -44,7 +44,7 @@ export default function ContractCard({ contract, onSelect }: Props) {
         )}
         <Button
           as={NextLink}
-          href={`#/contracts/${contract.id}`}
+          href={`/contracts/${contract.id}`}
           onClick={() => onSelect?.(contract.id)}
           colorScheme="brand"
           size="sm"


### PR DESCRIPTION
## Summary
- add dedicated pages for Jobs, Applications, Gigs, Manage Gigs, Interviews, Tasks, and Contracts
- include placeholder detail pages for jobs, gigs, and contracts
- correct contract card link to use proper route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898025d35fc83209f025411f625079d