### PR TITLE
Add networking sessions page and dashboard section

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,12 +1,25 @@
 "use client";
 
-import { Box } from "@chakra-ui/react";
+import { Box, Heading, SimpleGrid } from "@chakra-ui/react";
 import LiveFeed from "@/components/LiveFeed";
+import SessionCard from "@/components/SessionCard";
+import { networkingSessions } from "@/lib/sessions";
 
 export default function DashboardPage() {
   return (
     <Box bg="slate.50" minH="100vh">
       <LiveFeed />
+      <Box p={4}>
+        <Heading size="md" mb={4}>
+          Upcoming Sessions
+        </Heading>
+        <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
+          {networkingSessions.slice(0, 2).map((session) => (
+            <SessionCard key={session.id} session={session} />
+          ))}
+        </SimpleGrid>
+      </Box>
     </Box>
   );
 }
+

--- a/app/sessions/page.tsx
+++ b/app/sessions/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Box, Heading, SimpleGrid } from "@chakra-ui/react";
+import SessionCard from "@/components/SessionCard";
+import { networkingSessions } from "@/lib/sessions";
+
+export default function SessionsPage() {
+  return (
+    <Box p={4} bg="slate.50" minH="100vh">
+      <Heading mb={4}>Networking Sessions</Heading>
+      <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
+        {networkingSessions.map((session) => (
+          <SessionCard key={session.id} session={session} />
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}
+

--- a/lib/sessions.ts
+++ b/lib/sessions.ts
@@ -1,0 +1,47 @@
+import { NetworkingSession } from "@/lib/types/session";
+
+export const networkingSessions: NetworkingSession[] = [
+  {
+    id: 1,
+    title: "Tech Innovators Meetup",
+    description: "Connect with innovators across the tech industry.",
+    industry: "Technology",
+    topic: "Innovation",
+    date: new Date().toISOString(),
+    duration: 60,
+    capacity: 50,
+    price: 0,
+    type: "networking",
+    host: { id: 1, name: "Alice Johnson", image: "/next.svg" },
+    availableSeats: 35,
+  },
+  {
+    id: 2,
+    title: "Marketing Roundtable",
+    description: "Discuss the latest marketing trends and strategies.",
+    industry: "Marketing",
+    topic: "Growth",
+    date: new Date(Date.now() + 86400000).toISOString(),
+    duration: 45,
+    capacity: 40,
+    price: 15,
+    type: "networking",
+    host: { id: 2, name: "Brian Smith", image: "/next.svg" },
+    availableSeats: 12,
+  },
+  {
+    id: 3,
+    title: "Designers Collaboration Session",
+    description: "Share and critique design ideas with peers.",
+    industry: "Design",
+    topic: "UI/UX",
+    date: new Date(Date.now() + 2 * 86400000).toISOString(),
+    duration: 30,
+    capacity: 30,
+    price: 0,
+    type: "networking",
+    host: { id: 3, name: "Cleo Lee", image: "/next.svg" },
+    availableSeats: 5,
+  },
+];
+


### PR DESCRIPTION
## Summary
- add mock networking sessions data
- create sessions page to browse networking events
- display upcoming sessions on dashboard

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68980bb0c2148320a6e2262730e196de