### PR TITLE
Revamp dashboard layout and separate live feed

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,12 +1,49 @@
 "use client";
 
-import { Box } from "@chakra-ui/react";
-import LiveFeed from "@/components/LiveFeed";
+import {
+  Box,
+  Heading,
+  SimpleGrid,
+  VStack,
+  Link as ChakraLink,
+} from "@chakra-ui/react";
+import NextLink from "next/link";
+import SummaryWidget from "@/components/SummaryWidget";
+import CourseProgress from "@/components/CourseProgress";
+import DashboardCard from "@/components/DashboardCard";
 
 export default function DashboardPage() {
   return (
-    <Box bg="slate.50" minH="100vh">
-      <LiveFeed />
+    <Box bg="slate.50" minH="100vh" p={4}>
+      <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4} mb={8}>
+        <SummaryWidget label="Courses Enrolled" value={3} />
+        <SummaryWidget label="Jobs Applied" value={12} />
+        <SummaryWidget label="Tasks Completed" value={8} />
+      </SimpleGrid>
+
+      <Heading size="md" mb={4}>
+        Learning
+      </Heading>
+      <VStack align="stretch" spacing={4} mb={8}>
+        <CourseProgress
+          title="Intro to TypeScript"
+          progress={0.6}
+          nextSession="2024-08-01"
+          recommendation="Generics Deep Dive"
+        />
+        <CourseProgress
+          title="Next.js Fundamentals"
+          progress={0.3}
+          nextSession="2024-08-15"
+          recommendation="Routing Tutorial"
+        />
+      </VStack>
+
+      <DashboardCard title="Community">
+        <ChakraLink as={NextLink} href="/live-feed" color="brand.500">
+          View Live Feed
+        </ChakraLink>
+      </DashboardCard>
     </Box>
   );
 }

--- a/app/live-feed/page.tsx
+++ b/app/live-feed/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { Box } from "@chakra-ui/react";
+import LiveFeed from "@/components/LiveFeed";
+
+export default function LiveFeedPage() {
+  return (
+    <Box bg="slate.50" minH="100vh">
+      <LiveFeed />
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- Introduce high-level summary widgets and a learning section on the dashboard
- Move live feed to its own dedicated `/live-feed` route
- Link dashboard community card to the new live feed page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run check-all` (fails: Environment variable not found: DATABASE_URL)


------
https://chatgpt.com/codex/tasks/task_e_68980c248e588320ac1a40673a72bb38