### PR TITLE
Add services section pages

### DIFF
--- a/app/services/[id]/page.tsx
+++ b/app/services/[id]/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Box } from "@chakra-ui/react";
+import ServiceDetail from "@/components/ServiceDetail";
+import { Service } from "@/lib/types/service";
+import { use } from "react";
+
+export default function ServiceDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const service: Service = {
+    id: Number(id),
+    title: "Sample Service",
+    description: "Detailed description coming soon.",
+    price: 100,
+    status: "active",
+    seller: { id: 1, name: "Alice Johnson", image: "/next.svg" },
+    createdAt: new Date().toISOString(),
+  };
+
+  return (
+    <Box p={4}>
+      <ServiceDetail service={service} />
+    </Box>
+  );
+}
+

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Box, Heading, SimpleGrid } from "@chakra-ui/react";
+import ServiceCard from "@/components/ServiceCard";
+import { Service } from "@/lib/types/service";
+
+const services: Service[] = [
+  {
+    id: 1,
+    title: "House Cleaning",
+    description: "Professional house cleaning service.",
+    price: 80,
+    status: "active",
+    seller: { id: 1, name: "Alice Johnson", image: "/next.svg" },
+    createdAt: new Date().toISOString(),
+  },
+  {
+    id: 2,
+    title: "Dog Walking",
+    description: "Daily dog walking in your neighborhood.",
+    price: 20,
+    status: "active",
+    seller: { id: 2, name: "Bob Smith", image: "/next.svg" },
+    createdAt: new Date().toISOString(),
+  },
+];
+
+export default function ServicesPage() {
+  return (
+    <Box p={4}>
+      <Heading size="md" mb={4}>
+        Browse Services
+      </Heading>
+      <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={4}>
+        {services.map((service) => (
+          <ServiceCard key={service.id} service={service} />
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}
+

--- a/components/ServiceDetail.module.css
+++ b/components/ServiceDetail.module.css
@@ -1,0 +1,4 @@
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+}

--- a/components/ServiceDetail.tsx
+++ b/components/ServiceDetail.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import NextLink from "next/link";
+import {
+  Box,
+  Heading,
+  Text,
+  VStack,
+  HStack,
+  Button,
+  Avatar,
+  Divider,
+} from "@chakra-ui/react";
+import { Service } from "@/lib/types/service";
+import { formatCurrency } from "@/lib/utils/format";
+import styles from "./ServiceDetail.module.css";
+
+export default function ServiceDetail({ service }: { service: Service }) {
+  return (
+    <Box
+      className={styles.container}
+      bg="white"
+      borderWidth="1px"
+      borderRadius="md"
+      overflow="hidden"
+    >
+      <VStack align="start" p={6} spacing={4}>
+        <Heading size="lg">{service.title}</Heading>
+        <HStack spacing={3}>
+          <Avatar
+            name={service.seller.name || "Seller"}
+            src={service.seller.image || undefined}
+            size="sm"
+          />
+          <Text fontWeight="medium">{service.seller.name}</Text>
+        </HStack>
+        <Text fontSize="xl" color="brand.500" fontWeight="bold">
+          {formatCurrency(service.price)}
+        </Text>
+        <Text>{service.description}</Text>
+        <Divider />
+        <HStack spacing={4}>
+          <Button
+            as={NextLink}
+            href={`/checkout?serviceId=${service.id}`}
+            colorScheme="brand"
+          >
+            Book Service
+          </Button>
+          <Button
+            as={NextLink}
+            href={`/messages?recipient=${service.seller.id}`}
+            variant="outline"
+            colorScheme="brand"
+          >
+            Contact Seller
+          </Button>
+        </HStack>
+      </VStack>
+    </Box>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Services page listing sample offerings
- implement ServiceDetail component and detail route for individual services

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check-all` (fails: Environment variable not found: DATABASE_URL)


------
https://chatgpt.com/codex/tasks/task_e_68980c4350e08320bbffe72dd054749c