### PR TITLE
feat: add Apple-style CSS button component

### DIFF
--- a/components/AppleButton.module.css
+++ b/components/AppleButton.module.css
@@ -1,0 +1,24 @@
+.button {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 500;
+  color: #fff;
+  background: linear-gradient(180deg, #6ec0ff 0%, #007aff 100%);
+  border: none;
+  border-radius: 9999px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.button:hover {
+  background: linear-gradient(180deg, #80cfff 0%, #1a84ff 100%);
+  transform: translateY(-1px) scale(1.02);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25);
+}
+
+.button:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}

--- a/components/AppleButton.tsx
+++ b/components/AppleButton.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { type ButtonHTMLAttributes, type ReactNode } from "react";
+import styles from "./AppleButton.module.css";
+
+interface AppleButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function AppleButton({ children, className = "", ...props }: AppleButtonProps) {
+  return (
+    <button className={`${styles.button} ${className}`} {...props}>
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add CSS module for an Apple-inspired pill button with hover animation
- expose reusable `AppleButton` component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run check-all` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_6898115032fc83208595aea0058c65fc