### PR TITLE
feat: add mac-style dashboard widgets

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,22 +3,26 @@
 import { Box, Heading, SimpleGrid } from "@chakra-ui/react";
 import LiveFeed from "@/components/LiveFeed";
 import SessionCard from "@/components/SessionCard";
+import CalendarWidget from "@/components/CalendarWidget";
+import WeatherWidget from "@/components/WeatherWidget";
 import { networkingSessions } from "@/lib/sessions";
 
 export default function DashboardPage() {
   return (
-    <Box bg="slate.50" minH="100vh">
-      <LiveFeed />
-      <Box p={4}>
-        <Heading size="md" mb={4}>
-          Upcoming Sessions
-        </Heading>
-        <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
+    <Box bg="gray.900" minH="100vh" p={6} color="white">
+      <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={6}>
+        <WeatherWidget />
+        <CalendarWidget />
+        <LiveFeed />
+        <Box>
+          <Heading size="md" mb={4}>
+            Upcoming Sessions
+          </Heading>
           {networkingSessions.slice(0, 2).map((session) => (
             <SessionCard key={session.id} session={session} />
           ))}
-        </SimpleGrid>
-      </Box>
+        </Box>
+      </SimpleGrid>
     </Box>
   );
 }

--- a/components/CalendarWidget.module.css
+++ b/components/CalendarWidget.module.css
@@ -1,0 +1,40 @@
+.widget {
+  width: 200px;
+  background: white;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+}
+
+.header {
+  background: #c0392b;
+  color: #fff;
+  text-align: center;
+  padding: 0.5rem 0;
+  font-weight: 600;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: center;
+  padding: 0.5rem;
+  gap: 0.25rem;
+}
+
+.dayName {
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.day {
+  font-size: 0.875rem;
+  padding: 0.25rem 0;
+}
+
+.today {
+  background: #ff9500;
+  color: #fff;
+  border-radius: 4px;
+}

--- a/components/CalendarWidget.tsx
+++ b/components/CalendarWidget.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import styles from "./CalendarWidget.module.css";
+
+const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+export default function CalendarWidget() {
+  const now = new Date();
+  const month = now.getMonth();
+  const year = now.getFullYear();
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  const days: (number | string)[] = [];
+  for (let i = 0; i < firstDay; i++) {
+    days.push("");
+  }
+  for (let d = 1; d <= daysInMonth; d++) {
+    days.push(d);
+  }
+
+  return (
+    <div className={styles.widget}>
+      <div className={styles.header}>
+        {now.toLocaleString("default", { month: "long" })} {year}
+      </div>
+      <div className={styles.grid}>
+        {dayNames.map((name) => (
+          <div key={name} className={styles.dayName}>
+            {name}
+          </div>
+        ))}
+        {days.map((day, idx) => (
+          <div
+            key={idx}
+            className={`${styles.day} ${
+              day === now.getDate() ? styles.today : ""
+            }`}
+          >
+            {day}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/WeatherWidget.module.css
+++ b/components/WeatherWidget.module.css
@@ -1,0 +1,34 @@
+.widget {
+  width: 200px;
+  background: linear-gradient(#4f4f4f, #2f2f2f);
+  color: #fff;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  padding: 1rem;
+  font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+}
+
+.header {
+  text-align: center;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.body {
+  text-align: center;
+}
+
+.temp {
+  font-size: 48px;
+  font-weight: 300;
+  line-height: 1;
+}
+
+.meta {
+  font-size: 14px;
+}
+
+.loading {
+  text-align: center;
+}

--- a/components/WeatherWidget.tsx
+++ b/components/WeatherWidget.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import styles from "./WeatherWidget.module.css";
+
+interface Weather {
+  temperature: number;
+  windspeed: number;
+}
+
+export default function WeatherWidget() {
+  const [weather, setWeather] = useState<Weather | null>(null);
+
+  useEffect(() => {
+    async function fetchWeather() {
+      try {
+        const res = await fetch(
+          "https://api.open-meteo.com/v1/forecast?latitude=51.5072&longitude=0.1276&current_weather=true"
+        );
+        const data = await res.json();
+        setWeather(data.current_weather);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    fetchWeather();
+  }, []);
+
+  return (
+    <div className={styles.widget}>
+      <div className={styles.header}>Weather</div>
+      {weather ? (
+        <div className={styles.body}>
+          <div className={styles.temp}>{Math.round(weather.temperature)}°C</div>
+          <div className={styles.meta}>Wind {Math.round(weather.windspeed)} km/h</div>
+        </div>
+      ) : (
+        <div className={styles.loading}>Loading...</div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- style dashboard like macOS and add calendar and weather widgets
- show new widgets on dashboard alongside existing feed and sessions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run check-all` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_6898117babe08320be4cae1b164eead2