### PR TITLE
Fix Vercel build by adding global provider

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import ThemeToggle from "@/components/ThemeToggle";
+import { Providers } from "./providers";
 
 export const metadata: Metadata = {
   title: "Orbas | AI-Powered Talent Platform",
@@ -12,10 +13,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
-        <div style={{ position: "fixed", top: 16, right: 16 }}>
-          <ThemeToggle />
-        </div>
-        {children}
+        <Providers>
+          <div style={{ position: "fixed", top: 16, right: 16 }}>
+            <ThemeToggle />
+          </div>
+          {children}
+        </Providers>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- wrap `app/layout.tsx` with global `Providers` to ensure context is available during prerendering

## Testing
- `npm run vercel-build`


------
https://chatgpt.com/codex/tasks/task_e_6898cb4be5588320bc0079771deeb73a