### PR TITLE
feat: add opportunities pages and management

### DIFF
--- a/app/opportunities/[id]/page.tsx
+++ b/app/opportunities/[id]/page.tsx
@@ -1,0 +1,55 @@
+import { notFound } from "next/navigation";
+import {
+  Avatar,
+  Badge,
+  Container,
+  Heading,
+  Stack,
+  Text,
+  Button,
+} from "@chakra-ui/react";
+import Link from "next/link";
+import { getOpportunityById } from "@/lib/opportunities";
+
+interface Props {
+  params: { id: string };
+}
+
+export default function OpportunityDetail({ params }: Props) {
+  const id = Number(params.id);
+  const opportunity = getOpportunityById(id);
+
+  if (!opportunity) return notFound();
+
+  return (
+    <Container maxW="3xl" py={8}>
+      <Stack spacing={4}>
+        <Heading>{opportunity.title}</Heading>
+        <Text>{opportunity.description}</Text>
+        {typeof opportunity.compensation === "number" && (
+          <Text fontWeight="bold">
+            ${opportunity.compensation.toLocaleString()}
+          </Text>
+        )}
+        <Stack direction="row" spacing={2}>
+          <Badge colorScheme="green">{opportunity.status}</Badge>
+          {opportunity.category && <Badge>{opportunity.category}</Badge>}
+        </Stack>
+        {opportunity.provider && (
+          <Stack direction="row" align="center" mt={4}>
+            {opportunity.provider.image && (
+              <Avatar
+                src={opportunity.provider.image}
+                name={opportunity.provider.name}
+              />
+            )}
+            <Text fontWeight="medium">{opportunity.provider.name}</Text>
+          </Stack>
+        )}
+        <Button as={Link} href={`/applications/new?opportunity=${opportunity.id}`} mt={4}>
+          Apply Now
+        </Button>
+      </Stack>
+    </Container>
+  );
+}

--- a/app/opportunities/page.tsx
+++ b/app/opportunities/page.tsx
@@ -1,0 +1,20 @@
+import { Container, Heading, SimpleGrid } from "@chakra-ui/react";
+import OpportunityCard from "@/components/OpportunityCard";
+import { opportunities } from "@/lib/opportunities";
+
+export const metadata = {
+  title: "Opportunities | Orbas",
+};
+
+export default function OpportunitiesPage() {
+  return (
+    <Container maxW="6xl" py={8}>
+      <Heading mb={6}>Opportunities</Heading>
+      <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={6}>
+        {opportunities.map((op) => (
+          <OpportunityCard key={op.id} opportunity={op} />
+        ))}
+      </SimpleGrid>
+    </Container>
+  );
+}

--- a/app/opportunity-management/page.tsx
+++ b/app/opportunity-management/page.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  Container,
+  FormControl,
+  FormLabel,
+  Heading,
+  Input,
+  SimpleGrid,
+  Textarea,
+  VStack,
+} from "@chakra-ui/react";
+import OpportunityCard from "@/components/OpportunityCard";
+import { opportunities as initialData } from "@/lib/opportunities";
+import { Opportunity } from "@/lib/types/opportunity";
+
+export default function OpportunityManagement() {
+  const [items, setItems] = useState<Opportunity[]>(initialData);
+  const [form, setForm] = useState({
+    title: "",
+    description: "",
+    compensation: "",
+    status: "Open",
+  });
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const addOpportunity = (e: React.FormEvent) => {
+    e.preventDefault();
+    const newItem: Opportunity = {
+      id: items.length + 1,
+      title: form.title,
+      description: form.description,
+      compensation: form.compensation
+        ? Number(form.compensation)
+        : undefined,
+      status: form.status,
+      providerId: 0,
+    };
+    setItems([...items, newItem]);
+    setForm({ title: "", description: "", compensation: "", status: "Open" });
+  };
+
+  return (
+    <Container maxW="6xl" py={8}>
+      <Heading mb={6}>Opportunity Management</Heading>
+      <SimpleGrid columns={{ base: 1, md: 2 }} spacing={8}>
+        <Box as="form" onSubmit={addOpportunity}>
+          <VStack spacing={4} align="stretch">
+            <FormControl isRequired>
+              <FormLabel>Title</FormLabel>
+              <Input name="title" value={form.title} onChange={handleChange} />
+            </FormControl>
+            <FormControl isRequired>
+              <FormLabel>Description</FormLabel>
+              <Textarea
+                name="description"
+                value={form.description}
+                onChange={handleChange}
+              />
+            </FormControl>
+            <FormControl>
+              <FormLabel>Compensation</FormLabel>
+              <Input
+                type="number"
+                name="compensation"
+                value={form.compensation}
+                onChange={handleChange}
+              />
+            </FormControl>
+            <Button type="submit" alignSelf="flex-start">
+              Add Opportunity
+            </Button>
+          </VStack>
+        </Box>
+        <VStack align="stretch" spacing={4}>
+          {items.map((op) => (
+            <OpportunityCard key={op.id} opportunity={op} />
+          ))}
+        </VStack>
+      </SimpleGrid>
+    </Container>
+  );
+}

--- a/components/OpportunityCard.module.css
+++ b/components/OpportunityCard.module.css
@@ -1,7 +1,9 @@
 .card {
-  transition: box-shadow 0.2s ease-in-out;
+  background: #fff;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
+
 .card:hover {
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 0 8px rgba(0, 0, 0, 0.08);
 }

--- a/components/OpportunityCard.tsx
+++ b/components/OpportunityCard.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Box, Heading, Text, Badge, VStack } from "@chakra-ui/react";
+import {
+  Box,
+  Heading,
+  Text,
+  Badge,
+  VStack,
+  HStack,
+  Avatar,
+} from "@chakra-ui/react";
 import Link from "next/link";
 import { Opportunity } from "@/lib/types/opportunity";
 import styles from "./OpportunityCard.module.css";
@@ -21,15 +29,37 @@ export default function OpportunityCard({ opportunity }: Props) {
       _hover={{ shadow: "md" }}
     >
       <VStack align="start" spacing={2}>
+        {opportunity.provider && (
+          <HStack spacing={2} align="center">
+            {opportunity.provider.image && (
+              <Avatar
+                src={opportunity.provider.image}
+                name={opportunity.provider.name}
+                size="sm"
+              />
+            )}
+            <Text fontWeight="medium">{opportunity.provider.name}</Text>
+          </HStack>
+        )}
         <Heading size="md">{opportunity.title}</Heading>
         <Text noOfLines={2}>{opportunity.description}</Text>
+        {opportunity.location && (
+          <Text fontSize="sm" color="gray.600">
+            {opportunity.location}
+          </Text>
+        )}
         {typeof opportunity.compensation === "number" && (
-          <Text fontWeight="bold">${opportunity.compensation}</Text>
+          <Text fontWeight="bold">
+            ${opportunity.compensation.toLocaleString()}
+          </Text>
         )}
-        <Badge colorScheme="green">{opportunity.status}</Badge>
-        {opportunity.applicationStatus && (
-          <Badge colorScheme="blue">{opportunity.applicationStatus}</Badge>
-        )}
+        <HStack spacing={2}>
+          <Badge colorScheme="green">{opportunity.status}</Badge>
+          {opportunity.category && <Badge>{opportunity.category}</Badge>}
+          {opportunity.applicationStatus && (
+            <Badge colorScheme="blue">{opportunity.applicationStatus}</Badge>
+          )}
+        </HStack>
       </VStack>
     </Box>
   );

--- a/lib/opportunities.ts
+++ b/lib/opportunities.ts
@@ -1,0 +1,43 @@
+import { Opportunity } from "@/lib/types/opportunity";
+
+export const opportunities: Opportunity[] = [
+  {
+    id: 1,
+    title: "Junior Web Developer",
+    description: "Assist in building and maintaining modern web applications using React and Node.js.",
+    category: "Technology",
+    location: "Remote",
+    skills: "React, TypeScript, CSS",
+    compensation: 45000,
+    status: "Open",
+    providerId: 1,
+    provider: { id: 1, name: "Tech Corp", image: "/api/image" },
+  },
+  {
+    id: 2,
+    title: "Marketing Intern",
+    description: "Support the marketing team with campaign research, content creation, and analytics.",
+    category: "Marketing",
+    location: "New York, NY",
+    skills: "SEO, Content Writing",
+    compensation: 2000,
+    status: "Open",
+    providerId: 2,
+    provider: { id: 2, name: "Growth Gurus", image: "/api/image" },
+  },
+  {
+    id: 3,
+    title: "Community Cleanup Volunteer",
+    description: "Join our team to help organize and execute a neighborhood cleanup initiative.",
+    category: "Volunteer",
+    location: "San Francisco, CA",
+    skills: "Teamwork",
+    status: "Open",
+    providerId: 3,
+    provider: { id: 3, name: "City Helpers", image: "/api/image" },
+  },
+];
+
+export function getOpportunityById(id: number): Opportunity | undefined {
+  return opportunities.find((op) => op.id === id);
+}


### PR DESCRIPTION
## Summary
- implement opportunities listing and details pages with Chakra styling
- add management page with form to add new opportunities
- enhance OpportunityCard visuals and add mock data

## Testing
- `npm run check-all`


------
https://chatgpt.com/codex/tasks/task_e_6898e14784e88320a4f4c5d0fa31e6d9