### PR TITLE
Add full learning section pages

### DIFF
--- a/app/course-management/page.tsx
+++ b/app/course-management/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Box, Heading, SimpleGrid } from "@chakra-ui/react";
+import TeacherCourseCard from "@/components/TeacherCourseCard";
+import { teacherCourses } from "@/lib/courses";
+
+export default function CourseManagementPage() {
+  return (
+    <Box p={4}>
+      <Heading size="md" mb={4}>
+        Manage Courses
+      </Heading>
+      <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={4}>
+        {teacherCourses.map((course) => (
+          <TeacherCourseCard key={course.id} {...course} />
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}

--- a/app/education/page.tsx
+++ b/app/education/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Box, Heading, SimpleGrid } from "@chakra-ui/react";
+import CourseProgress from "@/components/CourseProgress";
+import { studentCourses } from "@/lib/courses";
+
+export default function EducationPage() {
+  return (
+    <Box p={4}>
+      <Heading size="md" mb={4}>
+        My Courses
+      </Heading>
+      <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={4}>
+        {studentCourses.map((course) => (
+          <CourseProgress key={course.id} {...course} />
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}

--- a/app/session-management/page.tsx
+++ b/app/session-management/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Box, Heading } from "@chakra-ui/react";
+import { useState } from "react";
+import SessionParticipantList from "@/components/SessionParticipantList";
+import { sessionParticipants } from "@/lib/sessions";
+
+export default function SessionManagementPage() {
+  const [participants, setParticipants] = useState(sessionParticipants);
+
+  const handleRemove = (userId: number) => {
+    setParticipants((prev) => prev.filter((p) => p.user.id !== userId));
+  };
+
+  return (
+    <Box p={4}>
+      <Heading size="md" mb={4}>
+        Session Participants
+      </Heading>
+      <SessionParticipantList
+        participants={participants}
+        onRemove={handleRemove}
+      />
+    </Box>
+  );
+}

--- a/lib/courses.ts
+++ b/lib/courses.ts
@@ -1,0 +1,37 @@
+import { Course, TeacherCourse } from "@/lib/types/course";
+
+export const studentCourses: Course[] = [
+  {
+    id: 1,
+    title: "Intro to Programming",
+    progress: 0.6,
+    nextSession: new Date().toISOString(),
+    recommendation: "Read Chapter 5",
+  },
+  {
+    id: 2,
+    title: "Advanced React",
+    progress: 0.3,
+    nextSession: new Date(Date.now() + 86400000).toISOString(),
+    recommendation: "Review hooks",
+  },
+];
+
+export const teacherCourses: TeacherCourse[] = [
+  {
+    id: 1,
+    title: "Design Systems",
+    studentCount: 25,
+    avgProgress: 0.75,
+    nextSession: new Date().toISOString(),
+    recommendation: "Prepare module 3",
+  },
+  {
+    id: 2,
+    title: "Data Structures",
+    studentCount: 30,
+    avgProgress: 0.5,
+    nextSession: new Date(Date.now() + 2 * 86400000).toISOString(),
+    recommendation: "Share practice problems",
+  },
+];

--- a/lib/sessions.ts
+++ b/lib/sessions.ts
@@ -1,4 +1,4 @@
-import { NetworkingSession } from "@/lib/types/session";
+import { NetworkingSession, SessionParticipant } from "@/lib/types/session";
 
 export const networkingSessions: NetworkingSession[] = [
   {
@@ -42,6 +42,36 @@ export const networkingSessions: NetworkingSession[] = [
     type: "networking",
     host: { id: 3, name: "Cleo Lee", image: "/next.svg" },
     availableSeats: 5,
+  },
+];
+
+export const sessionParticipants: SessionParticipant[] = [
+  {
+    id: 1,
+    user: {
+      id: 1,
+      name: "Alice Johnson",
+      image: "/next.svg",
+      title: "Engineer",
+    },
+  },
+  {
+    id: 2,
+    user: {
+      id: 2,
+      name: "Brian Smith",
+      image: "/next.svg",
+      title: "Marketer",
+    },
+  },
+  {
+    id: 3,
+    user: {
+      id: 3,
+      name: "Cleo Lee",
+      image: "/next.svg",
+      title: "Designer",
+    },
   },
 ];
 

--- a/lib/types/course.ts
+++ b/lib/types/course.ts
@@ -1,0 +1,16 @@
+export interface Course {
+  id: number;
+  title: string;
+  progress: number;
+  nextSession?: string | null;
+  recommendation?: string | null;
+}
+
+export interface TeacherCourse {
+  id: number;
+  title: string;
+  studentCount: number;
+  avgProgress: number;
+  nextSession?: string | null;
+  recommendation?: string | null;
+}

--- a/lib/types/session.ts
+++ b/lib/types/session.ts
@@ -24,3 +24,13 @@ export interface SessionRegistration {
   sessionId: number;
   participantId: number;
 }
+
+export interface SessionParticipant {
+  id: number;
+  user: {
+    id: number;
+    name: string | null;
+    image?: string | null;
+    title?: string | null;
+  };
+}


### PR DESCRIPTION
## Summary
- add course and session data models for learning features
- implement student education, course management, and session management pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run check-all`


------
https://chatgpt.com/codex/tasks/task_e_6898e161a1ac83209c4607f9f76b10bc