### PR TITLE
feat: add gig search and Apple theme

### DIFF
--- a/app/gig-management/page.tsx
+++ b/app/gig-management/page.tsx
@@ -1,6 +1,16 @@
 'use client';
 
-import { Box, Heading, SimpleGrid } from "@chakra-ui/react";
+import {
+  Box,
+  Heading,
+  SimpleGrid,
+  Input,
+  InputGroup,
+  InputLeftElement,
+} from "@chakra-ui/react";
+import { SearchIcon } from "@chakra-ui/icons";
+import { useMemo, useState } from "react";
+import Fuse from "fuse.js";
 import GigCard from "@/components/GigCard";
 import { Gig } from "@/lib/types/gig";
 
@@ -16,14 +26,37 @@ const myGigs: Gig[] = [
   },
 ];
 
+const fuse = new Fuse(myGigs, {
+  keys: ["title", "category"],
+  threshold: 0.3,
+});
+
 export default function GigManagementPage() {
+  const [query, setQuery] = useState("");
+
+  const results = useMemo(() => {
+    if (!query) return myGigs;
+    return fuse.search(query).map((res) => res.item);
+  }, [query]);
+
   return (
     <Box p={4}>
       <Heading size="md" mb={4}>
         Manage Gigs
       </Heading>
+      <InputGroup mb={4}>
+        <InputLeftElement pointerEvents="none">
+          <SearchIcon color="gray.400" />
+        </InputLeftElement>
+        <Input
+          placeholder="Search my gigs"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          bg="white"
+        />
+      </InputGroup>
       <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={4}>
-        {myGigs.map((gig) => (
+        {results.map((gig) => (
           <GigCard key={gig.id} gig={gig} />
         ))}
       </SimpleGrid>

--- a/app/gigs/page.tsx
+++ b/app/gigs/page.tsx
@@ -1,6 +1,16 @@
 'use client';
 
-import { Box, Heading, SimpleGrid } from "@chakra-ui/react";
+import {
+  Box,
+  Heading,
+  SimpleGrid,
+  Input,
+  InputGroup,
+  InputLeftElement,
+} from "@chakra-ui/react";
+import { SearchIcon } from "@chakra-ui/icons";
+import { useMemo, useState } from "react";
+import Fuse from "fuse.js";
 import GigCard from "@/components/GigCard";
 import { Gig } from "@/lib/types/gig";
 
@@ -25,14 +35,37 @@ const gigs: Gig[] = [
   },
 ];
 
+const fuse = new Fuse(gigs, {
+  keys: ["title", "category"],
+  threshold: 0.3,
+});
+
 export default function GigsPage() {
+  const [query, setQuery] = useState("");
+
+  const results = useMemo(() => {
+    if (!query) return gigs;
+    return fuse.search(query).map((res) => res.item);
+  }, [query]);
+
   return (
     <Box p={4}>
       <Heading size="md" mb={4}>
         Browse Gigs
       </Heading>
+      <InputGroup mb={4}>
+        <InputLeftElement pointerEvents="none">
+          <SearchIcon color="gray.400" />
+        </InputLeftElement>
+        <Input
+          placeholder="Search gigs"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          bg="white"
+        />
+      </InputGroup>
       <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={4}>
-        {gigs.map((gig) => (
+        {results.map((gig) => (
           <GigCard key={gig.id} gig={gig} />
         ))}
       </SimpleGrid>

--- a/components/GigCard.module.css
+++ b/components/GigCard.module.css
@@ -1,8 +1,10 @@
 .card {
-  transition: box-shadow 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
   cursor: pointer;
+  border-radius: 12px;
 }
 
 .card:hover {
-  box-shadow: var(--chakra-shadows-md);
+  transform: translateY(-2px);
+  box-shadow: var(--chakra-shadows-lg);
 }

--- a/components/GigCard.tsx
+++ b/components/GigCard.tsx
@@ -24,10 +24,11 @@ export default function GigCard({ gig }: { gig: Gig }) {
       as={NextLink}
       href={`/gigs/${gig.id}`}
       borderWidth="1px"
-      borderRadius="md"
+      borderRadius="lg"
       overflow="hidden"
       bg="white"
       position="relative"
+      boxShadow="sm"
       className={styles.card}
     >
       <IconButton

--- a/theme/index.ts
+++ b/theme/index.ts
@@ -5,22 +5,23 @@ const config: ThemeConfig = {
   useSystemColorMode: false,
 };
 
-const ocean = {
-  50: "#eff6ff",
-  100: "#dbeafe",
-  200: "#bfdbfe",
-  300: "#93c5fd",
-  400: "#60a5fa",
-  500: "#3b82f6",
-  600: "#2563eb",
-  700: "#1d4ed8",
-  800: "#1e40af",
-  900: "#1e3a8a",
+const apple = {
+  50: "#f0f7ff",
+  100: "#d4e6ff",
+  200: "#a9cdff",
+  300: "#7db4ff",
+  400: "#4596ff",
+  500: "#0071e3",
+  600: "#005bb5",
+  700: "#004088",
+  800: "#002f66",
+  900: "#001f44",
 };
 
 const colors = {
-  brand: ocean,
-  ocean,
+  brand: apple,
+  apple,
+  ocean: apple,
   sunset: {
     50: "#fff7ed",
     100: "#ffedd5",
@@ -103,8 +104,10 @@ const theme = extendTheme({
   config,
   colors,
   fonts: {
-    heading: "var(--font-geist-sans), sans-serif",
-    body: "var(--font-geist-sans), sans-serif",
+    heading:
+      '"SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+    body:
+      '"SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
   },
   components: {
     Button: {
@@ -128,8 +131,8 @@ const theme = extendTheme({
   styles: {
     global: {
       body: {
-        bg: "white",
-        color: "black",
+        bg: "#f5f5f7",
+        color: "#1d1d1f",
       },
     },
   },


### PR DESCRIPTION
## Summary
- introduce Apple-inspired Chakra theme with SF Pro fonts and accent palette
- add fuzzy search to gig browsing and management pages
- polish gig card hover styling for smoother interactions

## Testing
- `npm run lint`
- `npm run check-all`


------
https://chatgpt.com/codex/tasks/task_e_6898e24d98c88320a7a8205476e3426c