### PR TITLE
fix: update opportunity page params

### DIFF
--- a/app/opportunities/[id]/page.tsx
+++ b/app/opportunities/[id]/page.tsx
@@ -12,12 +12,12 @@ import Link from "next/link";
 import { getOpportunityById } from "@/lib/opportunities";
 
 interface Props {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
-export default function OpportunityDetail({ params }: Props) {
-  const id = Number(params.id);
-  const opportunity = getOpportunityById(id);
+export default async function OpportunityDetail({ params }: Props) {
+  const { id } = await params;
+  const opportunity = getOpportunityById(Number(id));
 
   if (!opportunity) return notFound();
 


### PR DESCRIPTION
## Summary
- adapt opportunity detail page to new Next.js params promise format

## Testing
- `npm run build`
- `node checks/runChecks.js`


------
https://chatgpt.com/codex/tasks/task_e_68991a74445083208b16296b6bbf4d3a